### PR TITLE
Fix updateSnippet verification

### DIFF
--- a/features/snippet/actions/index.ts
+++ b/features/snippet/actions/index.ts
@@ -194,6 +194,14 @@ export const updateSnippet = async (params: UpdateSnippetDTO) => {
     throw new Error(result.error.format()._errors?.join(";"));
   }
 
+  const existSnippet = await prisma.snippet.findUnique({
+    where: { id: result.data.id },
+  });
+
+  if (!existSnippet) {
+    throw new Error("Snippet不存在");
+  }
+
   const snippet = await prisma.snippet.update({
     where: { id: result.data.id },
     data: {
@@ -211,7 +219,5 @@ export const updateSnippet = async (params: UpdateSnippetDTO) => {
     include: { tags: true },
   });
 
-  if (!snippet) {
-    throw new Error("Snippet不存在");
-  }
+  return snippet;
 };


### PR DESCRIPTION
## Summary
- ensure `updateSnippet` verifies existence before updating
- return the updated snippet

## Testing
- `pnpm lint` *(fails: various unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684749886a548326aa987714063c4bd3