### PR TITLE
Fix blog toc anchors and improve code block

### DIFF
--- a/components/tiptap/editor.tsx
+++ b/components/tiptap/editor.tsx
@@ -1,19 +1,13 @@
 "use client";
 
+import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import Placeholder from "@tiptap/extension-placeholder";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import Placeholder from "@tiptap/extension-placeholder";
-import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
-import { createLowlight, common } from "lowlight";
-import asciidoc from "highlight.js/lib/languages/asciidoc";
-import dart from "highlight.js/lib/languages/dart";
-import nginx from "highlight.js/lib/languages/nginx";
+import { all, createLowlight } from "lowlight";
 import { Markdown } from "tiptap-markdown";
 
-const lowlight = createLowlight(common);
-lowlight.register({ asciidoc });
-lowlight.register({ dart });
-lowlight.register({ nginx });
+const lowlight = createLowlight(all);
 
 export type TiptapEditorProps = {
   body?: string;
@@ -21,13 +15,21 @@ export type TiptapEditorProps = {
   editorProps?: Parameters<typeof useEditor>[0]["editorProps"];
 };
 
-export const TiptapEditor = ({ body, setContent, editorProps }: TiptapEditorProps) => {
+export const TiptapEditor = ({
+  body,
+  setContent,
+  editorProps,
+}: TiptapEditorProps) => {
   const editor = useEditor({
     extensions: [
       StarterKit,
       CodeBlockLowlight.configure({ lowlight }),
       Placeholder.configure({ placeholder: "请输入内容..." }),
-      Markdown.configure({ html: false, transformCopiedText: true, transformPastedText: true }),
+      Markdown.configure({
+        html: false,
+        transformCopiedText: true,
+        transformPastedText: true,
+      }),
     ],
     content: body ?? "",
     editorProps,

--- a/components/tiptap/viewer.tsx
+++ b/components/tiptap/viewer.tsx
@@ -1,19 +1,16 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+
+import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
 import { Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
-import { createLowlight, common } from "lowlight";
-import asciidoc from "highlight.js/lib/languages/asciidoc";
-import dart from "highlight.js/lib/languages/dart";
-import nginx from "highlight.js/lib/languages/nginx";
+import { all, createLowlight } from "lowlight";
 import { Markdown } from "tiptap-markdown";
 
-const lowlight = createLowlight(common);
-lowlight.register({ asciidoc });
-lowlight.register({ dart });
-lowlight.register({ nginx });
+import { toSlug } from "@/lib/utils";
+
+const lowlight = createLowlight(all);
 
 export type TiptapViewerProps = {
   body: string;
@@ -26,11 +23,29 @@ export const TiptapViewer = ({ body }: TiptapViewerProps) => {
     if (!containerRef.current) return;
     const editor = new Editor({
       editable: false,
-      extensions: [StarterKit, CodeBlockLowlight.configure({ lowlight }), Markdown],
+      extensions: [
+        StarterKit,
+        CodeBlockLowlight.configure({ lowlight }),
+        Markdown,
+      ],
     });
     editor.commands.setContent(body);
     containerRef.current.innerHTML = editor.getHTML();
     editor.destroy();
+
+    const headings =
+      containerRef.current.querySelectorAll<HTMLElement>("h2, h3, h4, h5, h6");
+    headings.forEach((el) => {
+      const slug = toSlug(el.textContent || "");
+      el.id = slug;
+      if (!el.querySelector(".markdown-anchor")) {
+        const anchor = document.createElement("a");
+        anchor.href = `#${slug}`;
+        anchor.className = "markdown-anchor ml-2";
+        anchor.innerHTML = `#`;
+        el.appendChild(anchor);
+      }
+    });
 
     const preElements = containerRef.current.querySelectorAll("pre");
     preElements.forEach((pre) => {
@@ -39,6 +54,11 @@ export const TiptapViewer = ({ body }: TiptapViewerProps) => {
       const wrapper = document.createElement("div");
       wrapper.className = "code-block-wrapper";
       pre.parentNode?.insertBefore(wrapper, pre);
+      const header = document.createElement("div");
+      header.className = "code-block-header";
+      header.innerHTML =
+        '<span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>';
+      wrapper.appendChild(header);
       wrapper.appendChild(pre);
       const copyButton = document.createElement("button");
       copyButton.className = "copy-button";

--- a/styles/tiptap.css
+++ b/styles/tiptap.css
@@ -7,7 +7,7 @@
 }
 
 .tiptap-editor {
-  @apply rounded-xl border border-border bg-background text-foreground prose prose-neutral !max-w-full dark:prose-invert;
+  @apply prose prose-neutral !max-w-full rounded-xl border border-border bg-background text-foreground dark:prose-invert;
 }
 
 .tiptap-editor a {
@@ -15,7 +15,7 @@
 }
 
 .tiptap-editor pre {
-  @apply relative my-0 whitespace-break-spaces rounded-lg border bg-background/50 text-primary p-0;
+  @apply relative my-0 whitespace-break-spaces rounded-lg border bg-background/50 p-0 text-primary;
 }
 
 .tiptap-editor pre > code {
@@ -45,6 +45,30 @@
 
 .tiptap-editor :where(h2, h3, h4, h5, h6) .markdown-anchor {
   @apply order-2 opacity-0 transition-opacity;
+}
+
+.code-block-wrapper {
+  @apply my-4 overflow-hidden rounded-xl border bg-card text-card-foreground;
+}
+
+.code-block-header {
+  @apply flex items-center gap-2 border-b border-muted bg-muted px-3 py-2;
+}
+
+.code-block-header .dot {
+  @apply h-3 w-3 rounded-full;
+}
+
+.code-block-header .dot.red {
+  @apply bg-red-500 dark:bg-red-400;
+}
+
+.code-block-header .dot.yellow {
+  @apply bg-yellow-500 dark:bg-yellow-400;
+}
+
+.code-block-header .dot.green {
+  @apply bg-green-500 dark:bg-green-400;
 }
 
 .markdown-body {
@@ -115,7 +139,7 @@
 }
 
 .tiptap-editor {
-  @apply rounded-xl border border-border bg-background text-foreground prose prose-neutral !max-w-full dark:prose-invert;
+  @apply prose prose-neutral !max-w-full rounded-xl border border-border bg-background text-foreground dark:prose-invert;
 }
 
 .tiptap-editor a {
@@ -123,7 +147,7 @@
 }
 
 .tiptap-editor pre {
-  @apply relative my-0 whitespace-break-spaces rounded-lg border bg-background/50 text-primary p-0;
+  @apply relative my-0 whitespace-break-spaces rounded-lg border bg-background/50 p-0 text-primary;
 }
 
 .tiptap-editor pre > code {
@@ -154,4 +178,3 @@
 .tiptap-editor :where(h2, h3, h4, h5, h6) .markdown-anchor {
   @apply order-2 opacity-0 transition-opacity;
 }
-


### PR DESCRIPTION
## Summary
- ensure blog headings have slugs and add anchor links
- render code blocks with a mac-style wrapper
- switch to full language set for tiptap highlighting

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684763b5e3048326ade83b28a0cf6382