### PR TITLE
Improve auth pages and profile layout

### DIFF
--- a/features/auth/pages/sign-in-page.tsx
+++ b/features/auth/pages/sign-in-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { useForm } from "react-hook-form";
 
 import { useRouter } from "next/navigation";
@@ -26,7 +27,14 @@ import { Input } from "@/components/ui/input";
 
 import { IconBrandGithub, IconLogoGoogle } from "@/components/icons";
 import { ModeToggle } from "@/components/mode-toggle";
-import { showErrorToast } from "@/components/ui/toast";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 import { PATHS } from "@/constants";
 
@@ -39,6 +47,8 @@ import { type SignInDTO, signInSchema } from "../types";
 
 export const SignInPage = () => {
   const router = useRouter();
+  const [errorOpen, setErrorOpen] = React.useState(false);
+  const [errorMsg, setErrorMsg] = React.useState("");
   const form = useForm<SignInDTO>({
     resolver: zodResolver(signInSchema),
     defaultValues: { email: "", password: "" },
@@ -124,6 +134,14 @@ export const SignInPage = () => {
                 variant="default"
                 className="!w-full"
                 type="button"
+                onClick={handleGoSignUp}
+              >
+                注册
+              </Button>
+              <Button
+                variant="default"
+                className="!w-full"
+                type="button"
                 onClick={handleGoHome}
               >
                 回首页
@@ -132,6 +150,19 @@ export const SignInPage = () => {
           </Form>
         </CardFooter>
       </Card>
+      <AlertDialog open={errorOpen} onOpenChange={setErrorOpen}>
+        <AlertDialogContent>
+          <AlertDialogTrigger>
+            <AlertDialogTitle>登录失败</AlertDialogTitle>
+            <p className="mt-2 text-sm text-muted-foreground">{errorMsg}</p>
+          </AlertDialogTrigger>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setErrorOpen(false)}>
+              确定
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 
@@ -147,12 +178,17 @@ export const SignInPage = () => {
     router.push(PATHS.SITE_HOME);
   }
 
+  function handleGoSignUp() {
+    router.push(PATHS.AUTH_SIGN_UP);
+  }
+
   async function handleSubmit(values: SignInDTO) {
     try {
       const url = await signInWithCredentials(values);
       router.push(url);
     } catch (error) {
-      showErrorToast((error as Error).message);
+      setErrorMsg((error as Error).message);
+      setErrorOpen(true);
     }
   }
 };

--- a/features/auth/pages/sign-up-page.tsx
+++ b/features/auth/pages/sign-up-page.tsx
@@ -102,6 +102,13 @@ export const SignUpPage = () => {
               <Button type="submit" className="!w-full">
                 注册
               </Button>
+              <Button
+                type="button"
+                className="!w-full"
+                onClick={handleGoBack}
+              >
+                返回登录
+              </Button>
             </form>
           </Form>
         </CardFooter>
@@ -116,5 +123,9 @@ export const SignUpPage = () => {
     } catch (error) {
       showErrorToast((error as Error).message);
     }
+  }
+
+  function handleGoBack() {
+    router.push(PATHS.AUTH_SIGN_IN);
   }
 };

--- a/features/auth/types/index.ts
+++ b/features/auth/types/index.ts
@@ -20,3 +20,9 @@ export const updatePasswordSchema = z.object({
 });
 
 export type UpdatePasswordDTO = z.infer<typeof updatePasswordSchema>;
+
+export const updateNameSchema = z.object({
+  name: z.string().min(1, { message: "长度不能少于1个字符" }),
+});
+
+export type UpdateNameDTO = z.infer<typeof updateNameSchema>;

--- a/features/user/actions/index.ts
+++ b/features/user/actions/index.ts
@@ -6,8 +6,10 @@ import { ADMIN_EMAILS } from "@/constants";
 import {
   type SignupDTO,
   type UpdatePasswordDTO,
+  type UpdateNameDTO,
   signupSchema,
   updatePasswordSchema,
+  updateNameSchema,
 } from "@/features/auth";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
@@ -82,9 +84,25 @@ export const updateUserPassword = async (
   });
 };
 
+export const updateUserName = async (
+  userId: string,
+  params: UpdateNameDTO,
+) => {
+  const result = await updateNameSchema.safeParseAsync(params);
+  if (!result.success) {
+    const error = result.error.format()._errors?.join(";");
+    throw new Error(error);
+  }
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { name: result.data.name },
+  });
+};
+
 export const getUserAccounts = async (userId: string) => {
   return prisma.account.findMany({
     where: { userId },
-    select: { provider: true },
+    select: { provider: true, providerAccountId: true },
   });
 };

--- a/features/user/components/change-name-dialog.tsx
+++ b/features/user/components/change-name-dialog.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+import { ChangeNameForm } from "./change-name-form";
+
+type Props = {
+  userId: string;
+  defaultName: string;
+};
+
+export const ChangeNameDialog = ({ userId, defaultName }: Props) => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" onClick={() => setOpen(true)}>
+          修改用户名
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>修改用户名</DialogTitle>
+        </DialogHeader>
+        <ChangeNameForm userId={userId} defaultName={defaultName} />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/features/user/index.ts
+++ b/features/user/index.ts
@@ -1,3 +1,4 @@
 export * from "./actions";
 export * from "./components/change-password-form";
+export * from "./components/change-name-dialog";
 export * from "./pages/profile-page";

--- a/features/user/pages/profile-page.tsx
+++ b/features/user/pages/profile-page.tsx
@@ -10,6 +10,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
 import { ChangePasswordForm } from "../components/change-password-form";
+import { ChangeNameDialog } from "../components/change-name-dialog";
 
 export const ProfilePage = async () => {
   const session = await auth();
@@ -18,7 +19,7 @@ export const ProfilePage = async () => {
   }
   const accounts = await prisma.account.findMany({
     where: { userId: session.user.id },
-    select: { provider: true },
+    select: { provider: true, providerAccountId: true },
   });
   return (
     <AdminContentLayout
@@ -28,9 +29,9 @@ export const ProfilePage = async () => {
         />
       }
     >
-      <div className="space-y-6 px-4">
-        <div className="flex items-center space-x-4">
-          <Avatar className="size-10">
+      <div className="flex flex-col items-center space-y-6 px-4">
+        <div className="space-y-2 text-center">
+          <Avatar className="mx-auto size-20">
             <AvatarImage
               src={session.user.image ?? ""}
               alt={session.user.name ?? PLACEHOLDER_TEXT}
@@ -39,12 +40,21 @@ export const ProfilePage = async () => {
               {session.user.name ?? PLACEHOLDER_TEXT}
             </AvatarFallback>
           </Avatar>
-          <span>{session.user.name ?? PLACEHOLDER_TEXT}</span>
+          <p className="text-lg font-medium">
+            {session.user.name ?? PLACEHOLDER_TEXT}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {session.user.email}
+          </p>
         </div>
+        <ChangeNameDialog
+          userId={session.user.id}
+          defaultName={session.user.name ?? ""}
+        />
         <ChangePasswordForm userId={session.user.id} />
-        <div>
+        <div className="w-full">
           <p className="mb-2 font-medium">已连接的第三方登录:</p>
-          <ul className="flex space-x-4 pl-2">
+          <ul className="space-y-2 pl-2">
             {accounts.map((a) => (
               <li key={a.provider} className="flex items-center space-x-1">
                 {a.provider === "github" && (
@@ -53,7 +63,7 @@ export const ProfilePage = async () => {
                 {a.provider === "google" && (
                   <IconLogoGoogle className="size-4" />
                 )}
-                <span>{a.provider}</span>
+                <span>{a.providerAccountId}</span>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- show email and allow changing name in admin profile page
- add sign in error dialog, sign up link, and back button
- allow username update in backend actions
- expose ChangeNameDialog component

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d8ff09008326be9c6859a8c38f4f