### PR TITLE
Add login in footer and user menu

### DIFF
--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -6,13 +6,16 @@ import { buttonVariants } from "@/components/ui/button";
 
 import { PATHS, PATHS_MAP, SLOGAN, navItems } from "@/constants";
 import { getSiteStatistics } from "@/features/statistics";
+import { auth } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 import { formatNum } from "@/utils";
 
 import { Wrapper } from "../wrapper";
+import { FooterUserMenu } from "./user-menu";
 
 export const Footer = async () => {
   const { pv, uv, todayPV, todayUV } = await getSiteStatistics();
+  const session = await auth();
 
   return (
     <footer className="relative px-6 py-12">
@@ -65,15 +68,24 @@ export const Footer = async () => {
           &copy; {new Date().getFullYear()} {`Jiach`}&nbsp;&nbsp;·&nbsp;&nbsp;
           {SLOGAN}
         </div>
-        <Link
-          href={PATHS.AUTH_SIGN_UP}
-          className={cn(
-            buttonVariants({ variant: "ghost", size: "sm" }),
-            "absolute right-4 bottom-2",
-          )}
-        >
-          注册
-        </Link>
+        {session?.user ? (
+          <FooterUserMenu user={session.user} />
+        ) : (
+          <div className="absolute right-4 bottom-2 flex space-x-2">
+            <Link
+              href={PATHS.AUTH_SIGN_IN}
+              className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+            >
+              登录
+            </Link>
+            <Link
+              href={PATHS.AUTH_SIGN_UP}
+              className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+            >
+              注册
+            </Link>
+          </div>
+        )}
       </Wrapper>
     </footer>
   );

--- a/components/footer/user-menu.tsx
+++ b/components/footer/user-menu.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { SignOutDialog } from "@/features/auth";
+import { PATHS, PLACEHOLDER_TEXT } from "@/constants";
+import { cn } from "@/lib/utils";
+
+interface FooterUserMenuProps {
+  user: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+  };
+}
+
+export const FooterUserMenu = ({ user }: FooterUserMenuProps) => {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div className="absolute right-4 bottom-2 flex items-center space-x-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Avatar
+            className={cn(
+              buttonVariants({ variant: "outline", size: "icon" }),
+              "cursor-pointer",
+            )}
+          >
+            <AvatarImage
+              src={user.image ?? ""}
+              className="!size-6 rounded-[8px]"
+              alt={user.name ?? PLACEHOLDER_TEXT}
+            />
+            <AvatarFallback className="line-clamp-1 size-6 text-ellipsis rounded-[8px]">
+              {user.name ?? PLACEHOLDER_TEXT}
+            </AvatarFallback>
+          </Avatar>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel className="cursor-pointer">
+            我的账号
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => router.push(PATHS.ADMIN_PROFILE)}
+          >
+            个人信息
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => setOpen(true)}
+          >
+            退出登录
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <span className="text-sm">{user.name ?? PLACEHOLDER_TEXT}</span>
+      <SignOutDialog open={open} setOpen={setOpen} />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- display login & register buttons in footer when not logged in
- show avatar dropdown with username when logged in

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ELIFECYCLE Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6851e323f750832692f2eec16e54042e