### PR TITLE
Improve admin navigation and profile page

### DIFF
--- a/features/admin/components/layout/admin-content-layout.tsx
+++ b/features/admin/components/layout/admin-content-layout.tsx
@@ -135,6 +135,12 @@ export const AdminContentLayout = ({
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="cursor-pointer"
+                onClick={() => router.push(PATHS.SITE_HOME)}
+              >
+                返回首页
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="cursor-pointer"
                 onClick={() => setSettingsModalOpen(true)}
               >
                 设置

--- a/features/user/components/change-name-dialog.tsx
+++ b/features/user/components/change-name-dialog.tsx
@@ -31,7 +31,11 @@ export const ChangeNameDialog = ({ userId, defaultName }: Props) => {
         <DialogHeader>
           <DialogTitle>修改用户名</DialogTitle>
         </DialogHeader>
-        <ChangeNameForm userId={userId} defaultName={defaultName} />
+        <ChangeNameForm
+          userId={userId}
+          defaultName={defaultName}
+          setOpen={setOpen}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/features/user/components/change-name-form.tsx
+++ b/features/user/components/change-name-form.tsx
@@ -17,13 +17,21 @@ import { Input } from "@/components/ui/input";
 import { type UpdateNameDTO, updateNameSchema } from "@/features/auth";
 
 import { updateUserName } from "../actions";
+import {
+  hideToast,
+  showErrorToast,
+  showLoadingToast,
+  showSuccessToast,
+} from "@/components/ui/toast";
 
 export const ChangeNameForm = ({
   userId,
   defaultName,
+  setOpen,
 }: {
   userId: string;
   defaultName: string;
+  setOpen?: (open: boolean) => void;
 }) => {
   const form = useForm<UpdateNameDTO>({
     resolver: zodResolver(updateNameSchema),
@@ -52,7 +60,16 @@ export const ChangeNameForm = ({
   );
 
   async function handleSubmit(values: UpdateNameDTO) {
-    await updateUserName(userId, values);
-    form.reset(values);
+    const tid = showLoadingToast("正在更新用户名...");
+    try {
+      await updateUserName(userId, values);
+      form.reset(values);
+      showSuccessToast("用户名修改成功");
+      setOpen?.(false);
+    } catch (error) {
+      showErrorToast((error as Error).message);
+    } finally {
+      hideToast(tid);
+    }
   }
 };

--- a/features/user/pages/profile-page.tsx
+++ b/features/user/pages/profile-page.tsx
@@ -19,7 +19,10 @@ export const ProfilePage = async () => {
   }
   const accounts = await prisma.account.findMany({
     where: { userId: session.user.id },
-    select: { provider: true, providerAccountId: true },
+    select: {
+      provider: true,
+      user: { select: { email: true } },
+    },
   });
   return (
     <AdminContentLayout
@@ -29,7 +32,7 @@ export const ProfilePage = async () => {
         />
       }
     >
-      <div className="flex flex-col items-center space-y-6 px-4">
+      <div className="mx-auto flex w-full max-w-md flex-col items-center space-y-6 px-4">
         <div className="space-y-2 text-center">
           <Avatar className="mx-auto size-20">
             <AvatarImage
@@ -54,16 +57,16 @@ export const ProfilePage = async () => {
         <ChangePasswordForm userId={session.user.id} />
         <div className="w-full">
           <p className="mb-2 font-medium">已连接的第三方登录:</p>
-          <ul className="space-y-2 pl-2">
+          <ul className="space-y-2">
             {accounts.map((a) => (
-              <li key={a.provider} className="flex items-center space-x-1">
+              <li key={a.provider} className="flex items-center space-x-2">
                 {a.provider === "github" && (
                   <IconBrandGithub className="size-4" />
                 )}
                 {a.provider === "google" && (
                   <IconLogoGoogle className="size-4" />
                 )}
-                <span>{a.providerAccountId}</span>
+                <span>{a.user.email}</span>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- add link to go back to home from admin dropdown
- center profile contents and show account emails with provider icons
- show toast feedback when changing name and close dialog

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ELIFECYCLE command failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851e9be59248326b9960d9e3f3d73b3