### PR TITLE
feat: add bark notification support for OTP verification codes

### DIFF
--- a/app/api/auth/send-otp/route.ts
+++ b/app/api/auth/send-otp/route.ts
@@ -4,6 +4,7 @@ import { ActivityStatus, ResourceType } from "@prisma/client";
 import { Resend } from "resend";
 
 import { auth } from "@/lib/auth";
+import { notifyOtpCode } from "@/lib/notification";
 import { prisma } from "@/lib/prisma";
 import { safeLogActivity } from "@/lib/utils/activity-logger-helper";
 
@@ -92,6 +93,19 @@ export async function POST(req: NextRequest) {
         </div>
       `,
     });
+
+    // 发送bark通知
+    try {
+      await notifyOtpCode(
+        userEmail,
+        otp,
+        type,
+        new Date().toLocaleString("zh-CN", { timeZone: "Asia/Shanghai" }),
+      );
+    } catch (error) {
+      // bark通知失败不影响主流程，只记录错误
+      console.error("发送bark通知失败:", error);
+    }
 
     // 发送邮件成功后记录日志
     await safeLogActivity(session.user.id, "SEND_OTP", ActivityStatus.SUCCESS, {

--- a/lib/notification.ts
+++ b/lib/notification.ts
@@ -69,6 +69,14 @@ const NOTIFICATION_TEMPLATES = {
     category: "内容管理",
     icon: "https://r2.jiachz.com/jiachz-light.svg",
   },
+  OTP_CODE: {
+    title: "🔐 [验证码] 🔑",
+    body: "🔑 **验证码通知**\n\n📧 **邮箱:** {email}\n\n🔢 **验证码:** {code}\n\n🎯 **用途:** {type}\n\n🕒 **发送时间:** {time}\n\n⏰ **有效期:** 60秒\n\n🔐 请及时使用验证码完成验证！",
+    sound: "alert.caf",
+    group: "Blog",
+    category: "安全验证",
+    icon: "https://r2.jiachz.com/jiachz-light.svg",
+  },
 } as const;
 
 export type NotificationTemplateType = keyof typeof NOTIFICATION_TEMPLATES;
@@ -237,6 +245,25 @@ export async function notifyNewBlogCreated(
     title: truncatedTitle,
     author,
     status,
+    time,
+  });
+}
+
+export async function notifyOtpCode(
+  email: string,
+  code: string,
+  type: string,
+  time: string,
+): Promise<boolean> {
+  const typeMap: Record<string, string> = {
+    "email-verification": "邮箱验证",
+    "password-change": "修改密码",
+  };
+
+  return barkNotification.sendTemplateNotification("OTP_CODE", {
+    email,
+    code,
+    type: typeMap[type] || type,
     time,
   });
 }


### PR DESCRIPTION
## Summary
- Added bark notification integration for OTP verification codes
- Users now receive verification codes via both email and bark notifications
- Added new `OTP_CODE` template to notification system with proper formatting
- Integrated bark notifications in send-otp API endpoint for both email verification and password change scenarios

## Test plan
- [ ] Test email verification OTP sending (should trigger both email and bark notification)
- [ ] Test password change OTP sending (should trigger both email and bark notification)  
- [ ] Verify bark notification format includes email, code, type, and timestamp
- [ ] Confirm bark notification failures don't break main email flow
- [ ] Test with different OTP types (email-verification, password-change)

🤖 Generated with [Claude Code](https://claude.ai/code)