### PR TITLE
fix: correct syntax error in lib/redis.ts

### DIFF
--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -34,22 +34,6 @@ const createRedisInstance = () => {
       host: REDIS_HOST,
       port: REDIS_PORT ? Number(REDIS_PORT) : 6379,
       password: REDIS_PASSWORD ?? "",
-// 只有在配置了 KV_URL 或 REDIS_HOST 的情况下才创建真实的 Redis 实例
-const createRedisInstance = () => {
-  if (!KV_URL && !REDIS_HOST) {
-    // 如果没有配置，返回一个 Proxy 对象，调用任何方法都会报错，但会被业务逻辑的 try/catch 捕获
-    return new Proxy({} as RedisInstanceType, {
-      get: () => {
-        return () => {
-          throw new Error("Redis host/URL is not configured. Skipping redis operation.");
-        };
-      },
-    });
-  }
-
-  // 优先使用 Vercel KV 自动注入的连接字符串
-  if (KV_URL) {
-    const instance = new Redis(KV_URL, {
       keyPrefix: REDIS_KEY_PREFIX,
       maxRetriesPerRequest: 5,
       enableOfflineQueue: false,
@@ -57,7 +41,7 @@ const createRedisInstance = () => {
 
     instance.on("error", (err) => {
       // eslint-disable-next-line no-console
-      console.error("Vercel KV redis error: ", err);
+      console.error("redis error: ", err);
     });
 
     return instance;
@@ -68,29 +52,13 @@ const createRedisInstance = () => {
   return new Proxy({} as RedisInstanceType, {
     get: (target, prop) => {
       // Allow internal checks or methods that shouldn't crash
-      if (prop === "on" || prop === "quit") return () => {};
+      if (prop === "on" || prop === "quit" || prop === "then") return () => {};
       
       return () => {
         throw new Error(`Redis not configured. Skipping operation: ${String(prop)}`);
       };
     },
-  // 降级使用原本的离线自建 Redis 配置
-  const instance = new Redis({
-    host: REDIS_HOST,
-    port: REDIS_PORT ? Number(REDIS_PORT) : 6379,
-    password: REDIS_PASSWORD ?? "",
-    keyPrefix: REDIS_KEY_PREFIX,
-    maxRetriesPerRequest: 5,
-    enableOfflineQueue: false,
   });
-};
-
-  instance.on("error", (err) => {
-    // eslint-disable-next-line no-console
-    console.error("redis error: ", err);
-  });
-
-  return instance;
 };
 
 export const redis = (globalForRedis.redis ?? createRedisInstance()) as RedisInstanceType;


### PR DESCRIPTION
This PR fixes a syntax error in `lib/redis.ts` that was introduced during a previous merge. The error was causing Vercel builds to fail with an 'Unexpected token createRedisInstance' error.