### PR TITLE
fix: resolve vercel build error caused by botid update

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { Inter } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { BotIdClient } from "botid/react";
+import { BotIdClient } from "botid/client";
 
 import { NODE_ENV } from "@/config";
 
@@ -45,7 +45,7 @@ export default function RootLayout({
   return (
     <html lang="zh-CN" suppressHydrationWarning>
       <head>
-        <BotIdClient protect={["/api/auth/callback/credentials", "/api/message-board", "/api/auth/register"]} />
+        <BotIdClient protect={[{ path: "/api/auth/callback/credentials", method: "POST" }, { path: "/api/message-board", method: "POST" }, { path: "/api/auth/register", method: "POST" }]} />
         <link rel="icon" type="image/svg+xml" href={ImageAssets.logoDark} />
         {/*TODO*/}
         {/* Google Search Console 验证 */}


### PR DESCRIPTION
- Updated `BotIdClient` import path from `botid/react` to `botid/client` to fix the module not found error.
- Updated the `protect` prop array to pass objects with `path` and `method` as required by botid v1.5.11.