### PR TITLE
fix: resolve Vercel KV connection issues for site statistics

### DIFF
--- a/features/blog/actions/index.ts
+++ b/features/blog/actions/index.ts
@@ -4,7 +4,7 @@ import { type Prisma } from "@prisma/client";
 import { isUndefined } from "lodash-es";
 
 import { ERROR_NO_PERMISSION, PUBLISHED_MAP } from "@/constants";
-import { batchGetBlogUV } from "@/features/statistics";
+import { getBlogsUV } from "@/features/statistics";
 import { noPermission } from "@/features/user";
 import { notifyNewBlogCreated } from "@/lib/notification";
 import { prisma } from "@/lib/prisma";
@@ -124,12 +124,16 @@ export const getPublishedBlogs = async () => {
 
     const total = count ?? 0;
 
-    const m = await batchGetBlogUV(blogs?.map((el) => el.id));
+    const m = await getBlogsUV(blogs?.map((el) => el.id) || []);
+    const uvMap = new Map<string, number>();
+    blogs?.forEach((blog, idx) => {
+      uvMap.set(blog.id, m[idx] || 0);
+    });
 
     return {
       blogs,
       total,
-      uvMap: isUndefined(m) ? undefined : Object.fromEntries(m),
+      uvMap: Object.fromEntries(uvMap),
     };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -20,14 +20,18 @@ const globalForRedis = global as unknown as { redis: RedisInstanceType | null };
 const createRedisInstance = () => {
   try {
     // 1. Prioritize Vercel KV or Upstash URL (automatically injected in Vercel environment or integration)
-    const redisUrl = KV_URL || process.env.REDIS_URL || process.env.UPSTASH_REDIS_URL;
+    let redisUrl = KV_URL || process.env.REDIS_URL || process.env.UPSTASH_REDIS_URL;
     
     if (redisUrl) {
+      // Ensure Vercel KV / Upstash URLs use TLS by replacing redis:// with rediss://
+      if (redisUrl.startsWith("redis://") && (redisUrl.includes("vercel-storage.com") || redisUrl.includes("upstash.io"))) {
+        redisUrl = redisUrl.replace("redis://", "rediss://");
+      }
+
       // ioredis automatically handles rediss:// for TLS
       const instance = new Redis(redisUrl, {
         keyPrefix: REDIS_KEY_PREFIX,
         maxRetriesPerRequest: 5,
-        enableOfflineQueue: false,
         connectTimeout: 10000, // 10s timeout
       });
 
@@ -47,7 +51,6 @@ const createRedisInstance = () => {
         password: REDIS_PASSWORD ?? "",
         keyPrefix: REDIS_KEY_PREFIX,
         maxRetriesPerRequest: 5,
-        enableOfflineQueue: false,
         connectTimeout: 10000,
         // If it's a remote connection and not local, we might need TLS
         tls: REDIS_HOST !== "127.0.0.1" && REDIS_HOST !== "localhost" ? {} : undefined,


### PR DESCRIPTION
- Automatically replace `redis://` with `rediss://` for Vercel KV / Upstash URLs to enforce TLS connections.
- Removed `enableOfflineQueue: false` to allow ioredis to queue initial commands during serverless cold starts, preventing immediate 'Stream isn't writeable' errors.