### PR TITLE
[codex] fix navbar and markdown code blocks

### DIFF
--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -9,7 +9,7 @@ export default function Layout({ children }: React.PropsWithChildren) {
     <SessionProvider>
       <div className="min-h-screen">
         <Navbar />
-        <main className="relative z-[1] min-h-[calc(100vh-190px)]">
+        <main className="relative z-[1] min-h-[calc(100vh-190px)] pt-16">
           {children}
         </main>
         <Footer />

--- a/components/bytemd/config.ts
+++ b/components/bytemd/config.ts
@@ -6,13 +6,7 @@ import highlightSSR from "@bytemd/plugin-highlight-ssr";
 import mediumZoom from "@bytemd/plugin-medium-zoom";
 import { type EditorProps } from "@bytemd/react";
 import { merge } from "lodash-es";
-import { common } from "lowlight";
-
-// highlight需要额外扩充的高亮语言
-import asciidoc from "highlight.js/lib/languages/asciidoc";
-import dart from "highlight.js/lib/languages/dart";
-import java from "highlight.js/lib/languages/java";
-import nginx from "highlight.js/lib/languages/nginx";
+import { all } from "lowlight";
 
 import {
   codeBlockPlugin,
@@ -27,19 +21,8 @@ export const plugins = [
   mediumZoom(),
   gfm({ locale: gfm_zhHans }),
   highlightSSR({
-    languages: {
-      // @bytemd/plugin-highlight-ssr 是基于 rehype-highlight 的封装
-      // 而 rehype-highlight 是基于 lowlight 的封装
-      // 使用 lowlight 中一个叫 common 的配置对象，这个对象包含了常用的预定义的语言高亮配置，如 js,ts,go,css等等
-      // 为什么不导入全量的高亮语言配置是因为全量的配置太大了，只导入常用的语言高亮配置就够了，这样可以减少打包出来的体积
-      ...common,
-
-      // 默认common配置中没有以下几个语言高亮配置，这里我们自己加上
-      dart: dart, // flutter代码会用到dart
-      java: java, // Java语言高亮
-      nginx: nginx, // nginx配置文件高亮
-      asciidoc: asciidoc, // asciidoc高亮, 控制台输出信息高亮
-    },
+    ignoreMissing: true,
+    languages: all,
   }),
   codeBlockPlugin(), // 添加代码块插件来设置data-language属性
   inlineCodePlugin(),

--- a/components/bytemd/plugins/code-block.ts
+++ b/components/bytemd/plugins/code-block.ts
@@ -6,14 +6,15 @@ import { visit } from "unist-util-visit";
 
 import { copyToClipboard, isBrowser } from "@/lib/utils";
 
+const copyIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
+
 const copyBtnNode = fromHtmlIsomorphic(`
-<div class="copy-code-button">
-<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
-</div>
+<button type="button" class="copy-code-button" title="复制代码" aria-label="复制代码">
+${copyIcon}
+</button>
 `);
 
-const clipboardCheckIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy-check"><path d="m12 15 2 2 4-4"/><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
-const successTip = `<span style="font-size: 0.75em;">复制成功!</span>`;
+const clipboardCheckIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m12 15 2 2 4-4"/><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
 
 /**
  * 插件功能
@@ -35,9 +36,11 @@ export const codeBlockPlugin = (): BytemdPlugin => {
             );
 
             if (codeElement) {
-              const language = codeElement.properties?.className
-                ?.find((cls) => cls.startsWith("language-"))
-                ?.split("-")[1]
+              const languageClass = codeElement.properties?.className?.find(
+                (cls) => cls.startsWith("language-") || cls.startsWith("lang-"),
+              );
+              const language = languageClass
+                ?.replace(/^lang(uage)?-/, "")
                 ?.split(":")[0];
 
               if (language) {
@@ -46,7 +49,7 @@ export const codeBlockPlugin = (): BytemdPlugin => {
                   node.properties = {};
                 }
                 if (!node.properties["data-language"]) {
-                  node.properties["data-language"] = language;
+                  node.properties["data-language"] = language.toUpperCase();
                 }
               }
             }
@@ -62,24 +65,37 @@ export const codeBlockPlugin = (): BytemdPlugin => {
 
       const elements = markdownBody.querySelectorAll(".copy-code-button");
       for (const element of elements) {
+        if ((element as HTMLElement).dataset.copyBound === "true") {
+          continue;
+        }
+        (element as HTMLElement).dataset.copyBound = "true";
+
         // 点击按钮复制代码到粘贴板
         element.addEventListener("click", () => {
-          let codeText = element.textContent ?? "";
-          // 复制代码时去除开头的$符号，然后trim一下，一般是复制shell命令的代码块会用到
-          if (codeText.startsWith("$")) {
-            codeText = codeText.slice(1).trim();
-          }
-          copyToClipboard(element.parentElement?.textContent?.trim() || "");
+          void (async () => {
+            const code = element.parentElement?.querySelector("code");
+            let codeText = code?.textContent ?? "";
+            // 复制代码时去除开头的$符号，然后trim一下，一般是复制shell命令的代码块会用到
+            if (codeText.startsWith("$")) {
+              codeText = codeText.slice(1).trim();
+            }
+            const copied = await copyToClipboard(codeText);
+            if (!copied) {
+              return;
+            }
 
-          const tmp = element.innerHTML;
-          element.innerHTML = clipboardCheckIcon + successTip;
-          let timer = 0;
+            const tmp = element.innerHTML;
+            element.innerHTML = clipboardCheckIcon;
+            element.setAttribute("aria-label", "代码已复制");
+            let timer = 0;
 
-          timer = window.setTimeout(() => {
-            element.innerHTML = tmp;
-            window.clearTimeout(timer);
-            timer = 0;
-          }, 3 * 1000);
+            timer = window.setTimeout(() => {
+              element.innerHTML = tmp;
+              element.setAttribute("aria-label", "复制代码");
+              window.clearTimeout(timer);
+              timer = 0;
+            }, 3 * 1000);
+          })();
         });
       }
     },

--- a/components/bytemd/plugins/inline-code.ts
+++ b/components/bytemd/plugins/inline-code.ts
@@ -12,9 +12,12 @@ export const inlineCodePlugin = (): BytemdPlugin => {
   return {
     rehype: (process) =>
       process.use(() => (tree) => {
-        visit(tree, "element", (node) => {
+        visit(tree, "element", (node, _index, parent) => {
           // Handle inline code elements (not in pre blocks)
-          if (node.tagName === "code" && node.parent?.tagName !== "pre") {
+          if (
+            node.tagName === "code" &&
+            !(parent?.type === "element" && parent.tagName === "pre")
+          ) {
             // Add a class for styling
             if (!node.properties) {
               node.properties = {};

--- a/components/bytemd/viewer.tsx
+++ b/components/bytemd/viewer.tsx
@@ -1,109 +1,15 @@
 "use client";
 
-import React, { useEffect, useRef } from "react";
+import React from "react";
 
 import { Viewer } from "@bytemd/react";
 
 import { plugins, sanitize } from "./config";
-
-// 假设图标组件路径
-
-// 确保在你的项目中有一个合适的CSS文件来定义 .code-block-wrapper, .copy-button 等样式
-// 例如: styles/***.css
 
 type BytemdViewerProps = {
   body: string;
 };
 
 export const BytemdViewer = ({ body }: BytemdViewerProps) => {
-  const viewerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!viewerRef.current) return;
-
-    const preElements = viewerRef.current.querySelectorAll("pre");
-
-    preElements.forEach((pre) => {
-      // 防止重复添加按钮
-      if (pre.querySelector(".copy-code-button")) {
-        return;
-      }
-
-      // 添加样式类
-      pre.classList.add("enhanced-code-block");
-
-      const copyButton = document.createElement("button");
-      copyButton.className = "copy-code-button";
-      copyButton.title = "Copy code";
-      copyButton.setAttribute("aria-label", "Copy code to clipboard");
-
-      // 使用更优化的SVG图标
-      copyButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path></svg>`;
-
-      copyButton.addEventListener("click", () => {
-        void (async () => {
-          const codeElement = pre.querySelector("code");
-          let codeToCopy = codeElement ? codeElement.innerText : pre.innerText;
-
-          // 清理代码内容，移除语言标签
-          const languageLabel = pre.getAttribute("data-language");
-          if (languageLabel && codeToCopy.startsWith(languageLabel)) {
-            codeToCopy = codeToCopy.substring(languageLabel.length).trim();
-          }
-
-          try {
-            await navigator.clipboard.writeText(codeToCopy);
-            copyButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
-            copyButton.setAttribute("aria-label", "Code copied!");
-
-            // 添加成功动画效果
-            copyButton.style.transform = "scale(1.1)";
-            setTimeout(() => {
-              copyButton.style.transform = "scale(1)";
-            }, 150);
-
-            setTimeout(() => {
-              copyButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path></svg>`;
-              copyButton.setAttribute("aria-label", "Copy code to clipboard");
-            }, 2000);
-          } catch {
-            copyButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`;
-            copyButton.setAttribute("aria-label", "Copy failed");
-            setTimeout(() => {
-              copyButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path></svg>`;
-              copyButton.setAttribute("aria-label", "Copy code to clipboard");
-            }, 2000);
-          }
-        })();
-      });
-
-      // 直接将按钮添加到 pre 元素
-      pre.appendChild(copyButton);
-
-      // 添加语言标签到Mac按钮旁边
-      const language = pre.getAttribute("data-language");
-      if (language) {
-        const languageLabel = document.createElement("span");
-        languageLabel.className = "vscode-language-label";
-        languageLabel.textContent =
-          language.charAt(0).toUpperCase() + language.slice(1);
-        languageLabel.style.cssText = `
-          position: absolute;
-          top: 8px;
-          left: 70px;
-          font-size: 12px;
-          font-weight: 500;
-          z-index: 4;
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        `;
-        pre.appendChild(languageLabel);
-      }
-    });
-  }, [body]);
-
-  return (
-    <div ref={viewerRef}>
-      <Viewer value={body} plugins={plugins} sanitize={sanitize} />
-    </div>
-  );
+  return <Viewer value={body} plugins={plugins} sanitize={sanitize} />;
 };

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -47,7 +47,7 @@ export const Navbar = () => {
   return (
     <header
       className={cn(
-        "sticky top-0 z-30 flex w-full justify-center border-x-0 transition-[background-color,border-color,box-shadow] duration-300",
+        "fixed inset-x-0 top-0 z-50 flex w-full justify-center border-x-0 transition-[background-color,border-color,box-shadow] duration-300",
         "future-nav-glass border-transparent",
         (scroll?.top ?? 0) > 60 &&
           "border-[var(--future-line)] shadow-[0_18px_70px_rgb(0_0_0/0.2)]",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,19 +24,21 @@ export const toSlug = (s: string) => {
   });
 };
 
-export const copyToClipboard = (text: string) => {
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  const content = text?.trim();
   // 实测 Clipboard API 在 iPhone 上不支持，可恶！
   if (navigator.clipboard) {
-    navigator.clipboard
-      // 去除首尾空白字符
-      .writeText(text?.trim())
-      .then(() => {
-        toast.success("已复制到粘贴板");
-      })
-      .catch((error) => {
-        toast.error(error as string);
-      });
-  } else {
+    try {
+      await navigator.clipboard.writeText(content);
+      toast.success("已复制到粘贴板");
+      return true;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error));
+      return false;
+    }
+  }
+
+  try {
     // 以下代码来自：https://www.zhangxinxu.com/wordpress/2021/10/js-copy-paste-clipboard/
     const textarea = document.createElement("textarea");
     document.body.appendChild(textarea);
@@ -45,14 +47,22 @@ export const copyToClipboard = (text: string) => {
     textarea.style.clip = "rect(0 0 0 0)";
     textarea.style.top = "10px";
     // 赋值，手动去除首尾空白字符
-    textarea.value = text?.trim();
+    textarea.value = content;
     // 选中
     textarea.select();
     // 复制
-    document.execCommand("copy", true);
-    toast.success("已复制到粘贴板");
+    const copied = document.execCommand("copy", true);
+    if (copied) {
+      toast.success("已复制到粘贴板");
+    } else {
+      toast.error("复制失败，请手动复制代码");
+    }
     // 移除输入框
     document.body.removeChild(textarea);
+    return copied;
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : String(error));
+    return false;
   }
 };
 

--- a/styles/bytemd.css
+++ b/styles/bytemd.css
@@ -30,109 +30,6 @@
 .medium-zoom-overlay {
   @apply z-20 !bg-background;
 }
-/* VSCode window styling - Light theme */
-.markdown-body pre {
-  @apply relative !my-8 whitespace-break-spaces;
-  background: #ffffff;
-  border: 1px solid #e1e4e8;
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow:
-    0 8px 16px rgba(0, 0, 0, 0.1),
-    0 2px 4px rgba(0, 0, 0, 0.05);
-}
-
-/* Dark theme VSCode styling */
-.dark .markdown-body pre {
-  background: #1e1e1e;
-  border: 1px solid #3c3c3c;
-  box-shadow:
-    0 8px 16px rgba(0, 0, 0, 0.25),
-    0 2px 4px rgba(0, 0, 0, 0.15);
-}
-
-/* VSCode title bar - Light theme */
-.markdown-body pre::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 32px;
-  background: linear-gradient(to bottom, #f6f8fa, #e1e4e8);
-  border-bottom: 1px solid #d1d5da;
-  z-index: 2;
-}
-
-/* Dark theme title bar */
-.dark .markdown-body pre::before {
-  background: linear-gradient(to bottom, #3c3c3c, #2d2d2d);
-  border-bottom: 1px solid #1e1e1e;
-}
-
-/* Mac window control buttons - default */
-.markdown-body pre::after {
-  content: "";
-  position: absolute;
-  top: 10px;
-  left: 12px;
-  width: 12px;
-  height: 12px;
-  background: #ff5f57;
-  border-radius: 50%;
-  box-shadow:
-    20px 0 0 #ffbd2e,
-    40px 0 0 #28ca42;
-  z-index: 3;
-}
-
-/* Mac window control buttons for code blocks with data-language (override to ensure buttons show) */
-.markdown-body pre[data-language]::after {
-  /* First render the Mac buttons exactly like the default */
-  content: "";
-  position: absolute;
-  top: 10px;
-  left: 12px;
-  width: 12px;
-  height: 12px;
-  background: #ff5f57;
-  border-radius: 50%;
-  box-shadow:
-    20px 0 0 #ffbd2e,
-    40px 0 0 #28ca42;
-  z-index: 3;
-}
-
-/* Language label using ::before pseudo-element for pre elements with data-language */
-.markdown-body pre[data-language]::before {
-  /* Keep the existing title bar styling */
-  content: attr(data-language);
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 32px;
-  background: linear-gradient(to bottom, #f6f8fa, #e1e4e8);
-  border-bottom: 1px solid #d1d5da;
-  z-index: 2;
-  /* Add language text styling */
-  color: #586069;
-  font-size: 12px;
-  font-weight: 500;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  text-transform: capitalize;
-  line-height: 32px; /* Center vertically in title bar */
-  padding-left: 70px; /* Position after Mac buttons */
-  white-space: nowrap;
-}
-
-/* Dark theme for language label in title bar */
-.dark .markdown-body pre[data-language]::before {
-  background: linear-gradient(to bottom, #3c3c3c, #2d2d2d);
-  border-bottom: 1px solid #1e1e1e;
-  color: #cccccc;
-}
 .markdown-body code::-webkit-scrollbar {
   @apply h-1.5 w-1.5;
 }
@@ -242,122 +139,155 @@
   color: #fb923c;
 }
 
-/* VSCode code content styling - Light theme */
-.markdown-body pre > code {
-  @apply mx-4 my-4 !whitespace-pre-wrap !break-words text-sm leading-relaxed;
+/* Blog code blocks */
+.markdown-body {
+  --markdown-code-bg: #090b10;
+  --markdown-code-bg-soft: #111722;
+  --markdown-code-border: rgb(148 163 184 / 0.24);
+  --markdown-code-header: rgb(255 255 255 / 0.07);
+  --markdown-code-text: #e8edf5;
+  --markdown-code-muted: rgb(226 232 240 / 0.64);
+  --markdown-code-accent: #22d3ee;
+  --markdown-code-shadow:
+    0 24px 70px rgb(15 23 42 / 0.22), inset 0 1px 0 rgb(255 255 255 / 0.08);
+}
+
+.dark .markdown-body {
+  --markdown-code-bg: #07080d;
+  --markdown-code-bg-soft: #10141d;
+  --markdown-code-border: rgb(255 255 255 / 0.14);
+  --markdown-code-header: rgb(255 255 255 / 0.065);
+  --markdown-code-text: #eef2f8;
+  --markdown-code-muted: rgb(226 232 240 / 0.6);
+  --markdown-code-shadow:
+    0 24px 80px rgb(0 0 0 / 0.36), inset 0 1px 0 rgb(255 255 255 / 0.08);
+}
+
+.markdown-body pre {
+  position: relative;
+  margin: 2rem 0;
+  border: 1px solid var(--markdown-code-border);
+  border-radius: 1rem;
+  background:
+    radial-gradient(
+      circle at 14% 0%,
+      color-mix(in srgb, var(--markdown-code-accent) 22%, transparent),
+      transparent 18rem
+    ),
+    linear-gradient(
+      145deg,
+      var(--markdown-code-bg-soft),
+      var(--markdown-code-bg) 58%
+    );
+  box-shadow: var(--markdown-code-shadow);
+  color: var(--markdown-code-text);
+  overflow: hidden;
+}
+
+.markdown-body pre::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3.25rem;
+  border-bottom: 1px solid var(--markdown-code-border);
+  background:
+    linear-gradient(90deg, rgb(255 255 255 / 0.08), transparent 52%),
+    var(--markdown-code-header);
+  pointer-events: none;
+}
+
+.markdown-body pre[data-language]::after {
+  content: attr(data-language);
+  position: absolute;
+  top: 0.95rem;
+  left: 1rem;
+  right: 4rem;
+  z-index: 1;
+  overflow: hidden;
+  color: var(--markdown-code-muted);
   font-family:
     "SF Mono", "Monaco", "Menlo", "Consolas", "Courier New", monospace;
-  color: #24292e;
-  background: transparent !important;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.markdown-body pre > code,
+.markdown-body pre > code.hljs {
   display: block;
-  margin-top: 44px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  font-size: 13px;
-  line-height: 1.5;
-}
-
-/* Dark theme code content */
-.dark .markdown-body pre > code {
-  color: #d4d4d4;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 4.35rem 1.25rem 1.25rem;
   background: transparent !important;
-}
-
-/* Copy button positioned properly in title bar */
-.markdown-body pre > .copy-code-button {
-  @apply absolute right-4 z-[4] flex h-6 w-6 cursor-pointer items-center justify-center text-sm transition-all duration-200 ease-in-out;
-  top: 13px; /* Centered in 32px title bar */
-  background: linear-gradient(
-    135deg,
-    rgb(255 255 255 / 0.9),
-    rgb(248 250 252 / 0.9)
-  );
-  border: 1px solid rgb(226 232 240 / 0.8);
-  border-radius: 0.375rem;
-  box-shadow:
-    0 1px 3px rgb(0 0 0 / 0.1),
-    inset 0 1px 0 rgb(255 255 255 / 0.6);
-  color: rgb(71 85 105);
-  opacity: 0.8;
-}
-
-.dark .markdown-body pre > .copy-code-button {
-  background: linear-gradient(135deg, rgb(39 39 42 / 0.9), rgb(24 24 27 / 0.9));
-  border: 1px solid rgb(63 63 70 / 0.8);
-  box-shadow:
-    0 1px 3px rgb(0 0 0 / 0.2),
-    inset 0 1px 0 rgb(255 255 255 / 0.05);
-  color: rgb(148 163 184);
-}
-
-/* Copy button hover effect */
-.markdown-body pre > .copy-code-button:hover {
-  opacity: 1;
-  transform: translateY(-1px);
-  box-shadow:
-    0 4px 6px rgb(0 0 0 / 0.15),
-    inset 0 1px 0 rgb(255 255 255 / 0.8);
-  background: linear-gradient(135deg, rgb(255 255 255), rgb(248 250 252));
-}
-
-.dark .markdown-body pre > .copy-code-button:hover {
-  box-shadow:
-    0 4px 6px rgb(0 0 0 / 0.3),
-    inset 0 1px 0 rgb(255 255 255 / 0.08);
-  background: linear-gradient(135deg, rgb(55 65 81 / 0.9), rgb(39 39 42 / 0.9));
-}
-
-/* Copy button active state */
-.markdown-body pre > .copy-code-button:active {
-  transform: translateY(0);
-  box-shadow:
-    0 1px 2px rgb(0 0 0 / 0.1),
-    inset 0 1px 3px rgb(0 0 0 / 0.1);
-}
-
-/* Legacy language label styling for compatibility */
-.vscode-language-label {
-  color: #586069 !important;
-}
-
-.dark .vscode-language-label {
-  color: #cccccc !important;
-}
-
-/* Remove any language-specific styling to keep VSCode look clean */
-
-/* Enhanced syntax highlighting improvements */
-.hljs-keyword,
-.hljs-selector-tag,
-.hljs-literal,
-.hljs-section,
-.hljs-link {
-  font-weight: 600;
-}
-
-.hljs-string,
-.hljs-attr {
-  font-style: normal;
-}
-
-.hljs-comment {
-  font-style: italic;
-  opacity: 0.8;
-}
-
-/* Code block scroll improvements */
-.markdown-body pre > code {
+  color: var(--markdown-code-text);
+  font-family:
+    "SF Mono", "Monaco", "Menlo", "Consolas", "Courier New", monospace;
+  font-size: 0.86rem;
+  line-height: 1.78;
+  scrollbar-color: color-mix(
+      in srgb,
+      var(--markdown-code-accent) 46%,
+      transparent
+    )
+    transparent;
   scrollbar-width: thin;
-  scrollbar-color: rgb(203 213 225 / 0.5) transparent;
+  white-space: pre;
 }
 
-.dark .markdown-body pre > code {
-  scrollbar-color: rgb(75 85 99 / 0.5) transparent;
+.markdown-body pre > .copy-code-button {
+  position: absolute;
+  top: 0.62rem;
+  right: 0.75rem;
+  z-index: 2;
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--markdown-code-border);
+  border-radius: 0.68rem;
+  background: rgb(255 255 255 / 0.08);
+  color: var(--markdown-code-text);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.08);
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.markdown-body pre > .copy-code-button:hover {
+  border-color: color-mix(
+    in srgb,
+    var(--markdown-code-accent) 52%,
+    var(--markdown-code-border)
+  );
+  background: color-mix(
+    in srgb,
+    var(--markdown-code-accent) 16%,
+    rgb(255 255 255 / 0.08)
+  );
+  color: white;
+  transform: translateY(-1px);
+}
+
+.markdown-body pre > .copy-code-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--markdown-code-accent) 74%, white);
+  outline-offset: 2px;
+}
+
+.markdown-body pre > .copy-code-button svg {
+  width: 1rem;
+  height: 1rem;
 }
 
 .markdown-body pre > code::-webkit-scrollbar {
-  height: 6px;
-  width: 6px;
+  height: 0.55rem;
 }
 
 .markdown-body pre > code::-webkit-scrollbar-track {
@@ -365,102 +295,102 @@
 }
 
 .markdown-body pre > code::-webkit-scrollbar-thumb {
-  background: rgb(203 213 225 / 0.5);
-  border-radius: 3px;
+  border: 0.18rem solid transparent;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--markdown-code-accent) 42%, transparent);
+  background-clip: padding-box;
 }
 
-.dark .markdown-body pre > code::-webkit-scrollbar-thumb {
-  background: rgb(75 85 99 / 0.5);
-}
-
-.markdown-body pre > code::-webkit-scrollbar-thumb:hover {
-  background: rgb(156 163 175 / 0.7);
-}
-
-.dark .markdown-body pre > code::-webkit-scrollbar-thumb:hover {
-  background: rgb(107 114 128 / 0.7);
-}
-
-/* Remove unnecessary animations for cleaner look */
-
-/* Enhanced focus states for accessibility */
-.markdown-body pre:focus-within {
-  outline: 2px solid rgb(59 130 246 / 0.5);
-  outline-offset: 2px;
-}
-
-.dark .markdown-body pre:focus-within {
-  outline: 2px solid rgb(96 165 250 / 0.5);
-}
-
-/* Improved text selection in code blocks */
 .markdown-body pre code::selection {
-  background: rgba(59, 130, 246, 0.2);
+  background: color-mix(in srgb, var(--markdown-code-accent) 26%, transparent);
   color: inherit;
 }
 
-.dark .markdown-body pre code::selection {
-  background: rgba(96, 165, 250, 0.3);
-  color: inherit;
+.markdown-body pre .hljs,
+.markdown-body pre .hljs-subst {
+  color: var(--markdown-code-text);
 }
 
-/* Better line height for readability */
-.markdown-body pre code {
-  line-height: 1.6;
+.markdown-body pre .hljs-comment,
+.markdown-body pre .hljs-quote {
+  color: #7c8da6;
+  font-style: italic;
 }
 
-/* VSCode window mobile responsive improvements */
+.markdown-body pre .hljs-keyword,
+.markdown-body pre .hljs-selector-tag,
+.markdown-body pre .hljs-literal,
+.markdown-body pre .hljs-section,
+.markdown-body pre .hljs-link,
+.markdown-body pre .hljs-type {
+  color: #ff8a8a;
+  font-weight: 700;
+}
+
+.markdown-body pre .hljs-title,
+.markdown-body pre .hljs-title.class_,
+.markdown-body pre .hljs-title.function_ {
+  color: #f7c873;
+}
+
+.markdown-body pre .hljs-string,
+.markdown-body pre .hljs-regexp,
+.markdown-body pre .hljs-symbol,
+.markdown-body pre .hljs-bullet {
+  color: #9ae6b4;
+}
+
+.markdown-body pre .hljs-attr,
+.markdown-body pre .hljs-attribute,
+.markdown-body pre .hljs-name,
+.markdown-body pre .hljs-variable,
+.markdown-body pre .hljs-template-variable,
+.markdown-body pre .hljs-selector-class,
+.markdown-body pre .hljs-selector-id {
+  color: #7dd3fc;
+}
+
+.markdown-body pre .hljs-number,
+.markdown-body pre .hljs-meta,
+.markdown-body pre .hljs-built_in,
+.markdown-body pre .hljs-operator {
+  color: #c4b5fd;
+}
+
+.markdown-body pre .hljs-addition {
+  color: #86efac;
+  background: rgb(22 101 52 / 0.22);
+}
+
+.markdown-body pre .hljs-deletion {
+  color: #fca5a5;
+  background: rgb(153 27 27 / 0.22);
+}
+
 @media (max-width: 768px) {
   .markdown-body pre {
-    margin-left: -0.5rem;
-    margin-right: -0.5rem;
-    border-radius: 8px;
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    border-radius: 0.9rem;
   }
 
-  .markdown-body pre > code {
-    padding-left: 1rem;
-    padding-right: 1rem;
-    font-size: 12px;
+  .markdown-body pre[data-language]::after {
+    left: 0.9rem;
+    right: 3.45rem;
+    font-size: 0.66rem;
   }
 
-  .vscode-language-label {
-    left: 55px !important;
-    font-size: 11px !important;
+  .markdown-body pre > code,
+  .markdown-body pre > code.hljs {
+    padding: 4rem 1rem 1.05rem;
+    font-size: 0.78rem;
+    line-height: 1.72;
   }
 
   .markdown-body pre > .copy-code-button {
-    right: 6px;
-    top: 11px;
-    height: 5px;
-    width: 5px;
-  }
-
-  /* Adjust Mac window buttons for mobile */
-  .markdown-body pre::after {
-    width: 10px;
-    height: 10px;
-    top: 9px;
-    left: 10px;
-    box-shadow:
-      16px 0 0 #ffbd2e,
-      32px 0 0 #28ca42;
-  }
-
-  /* Adjust Mac window buttons for mobile */
-  .markdown-body pre[data-language]::after {
-    width: 10px;
-    height: 10px;
-    top: 9px;
-    left: 10px;
-    box-shadow:
-      16px 0 0 #ffbd2e,
-      32px 0 0 #28ca42;
-  }
-
-  /* Adjust language label for mobile */
-  .markdown-body pre[data-language]::before {
-    padding-left: 55px;
-    font-size: 11px;
+    right: 0.62rem;
+    width: 1.85rem;
+    height: 1.85rem;
   }
 }
 .markdown-body iframe {
@@ -522,6 +452,12 @@
 /* Public blog reading surface */
 .future-site .markdown-body {
   @apply !max-w-none;
+  --markdown-code-bg: #08090c;
+  --markdown-code-bg-soft: #11131a;
+  --markdown-code-border: var(--future-line);
+  --markdown-code-header: rgb(255 255 255 / 0.065);
+  --markdown-code-accent: var(--future-cyan);
+  --markdown-code-shadow: var(--future-shadow), var(--future-inner);
   color: var(--future-ink);
   font-family:
     Inter, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei",
@@ -652,43 +588,6 @@
   padding: 0.12rem 0.34rem;
 }
 
-.future-site .markdown-body pre {
-  border: 1px solid var(--future-line);
-  border-radius: 1.35rem;
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.055), transparent 3rem), #07080b;
-  box-shadow: var(--future-shadow);
-  overflow-x: auto;
-}
-
-.future-site .markdown-body pre::before,
-.future-site .markdown-body pre[data-language]::before {
-  background: linear-gradient(
-    180deg,
-    rgb(255 255 255 / 0.08),
-    rgb(255 255 255 / 0.025)
-  );
-  border-bottom: 1px solid var(--future-line);
-  color: rgb(255 255 255 / 0.54);
-  font-family: "SF Mono", "Monaco", "Menlo", monospace;
-  letter-spacing: 0.16em;
-}
-
-.future-site .markdown-body pre > code {
-  display: block;
-  color: #f2eee8;
-  font-size: 0.9rem;
-  line-height: 1.8;
-  min-width: max-content;
-  white-space: pre;
-}
-
-.future-site .markdown-body pre > .copy-code-button {
-  border-color: var(--future-line);
-  background: rgb(255 255 255 / 0.08);
-  color: #f2eee8;
-}
-
 @media (max-width: 768px) {
   .future-site .markdown-body {
     font-size: 1.01rem;
@@ -702,11 +601,6 @@
 
   .future-site .markdown-body h3 {
     font-size: 1.45rem;
-  }
-
-  .future-site .markdown-body pre {
-    margin-left: -0.25rem;
-    margin-right: -0.25rem;
   }
 }
 /* 下面代码的灵感来自这个Issue: https://github.com/pd4d10/hashmd/issues/40 */

--- a/styles/global.css
+++ b/styles/global.css
@@ -122,6 +122,11 @@
       "rlig" 1,
       "calt" 1;
   }
+
+  html,
+  body {
+    overscroll-behavior-y: none;
+  }
 }
 /* 适配 shiki 深色模式 */
 html.dark .shiki,


### PR DESCRIPTION
## Summary
- Keep the public navbar fixed at the top and prevent overscroll pull-away behavior.
- Rework ByteMD code block rendering into a single plugin/CSS path with lowlight all-language highlighting.
- Fix code copy failure handling so clipboard permission errors render as toast text instead of crashing the app.

## Validation
- pnpm exec eslint components/navbar/navbar.tsx app/(root)/layout.tsx components/bytemd/config.ts components/bytemd/plugins/code-block.ts components/bytemd/plugins/inline-code.ts components/bytemd/viewer.tsx lib/utils.ts
- pnpm exec prettier --check components/navbar/navbar.tsx app/(root)/layout.tsx components/bytemd/config.ts components/bytemd/plugins/code-block.ts components/bytemd/plugins/inline-code.ts components/bytemd/viewer.tsx lib/utils.ts styles/bytemd.css styles/global.css
- Browser verification on local dev server for navbar fixed positioning and multi-language code block rendering.

## Notes
- Full tsc still fails on existing unrelated repository type errors in coming-soon, activity logs, auth routes, currency converter, note actions, and activity logger.