### PR TITLE
[codex] polish markdown rendering

### DIFF
--- a/app/(root)/blog/[slug]/page.tsx
+++ b/app/(root)/blog/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from "next/navigation";
 
 import { isNil } from "lodash-es";
 
+import { renderMarkdown } from "@/components/bytemd/render-markdown";
+
 import { BlogDetailPage, getPublishedBlogBySlug } from "@/features/blog";
 import { getBlogUV } from "@/features/statistics";
 
@@ -19,6 +21,7 @@ export default async function Page({
   }
 
   const uv = await getBlogUV(blog.id);
+  const markdown = renderMarkdown(blog.body || "");
 
-  return <BlogDetailPage blog={blog} uv={uv} />;
+  return <BlogDetailPage blog={blog} markdown={markdown} uv={uv} />;
 }

--- a/components/bytemd/config.ts
+++ b/components/bytemd/config.ts
@@ -6,14 +6,23 @@ import highlightSSR from "@bytemd/plugin-highlight-ssr";
 import mediumZoom from "@bytemd/plugin-medium-zoom";
 import { type EditorProps } from "@bytemd/react";
 import { merge } from "lodash-es";
-import { all } from "lowlight";
 
 import {
   codeBlockPlugin,
   headingPlugin,
   inlineCodePlugin,
   prettyLinkPlugin,
+  tablePlugin,
 } from "./plugins";
+
+const highlightAliases = {
+  bash: ["sh", "shell", "zsh"],
+  javascript: ["js", "jsx"],
+  markdown: ["md", "mdx"],
+  plaintext: ["text", "txt"],
+  typescript: ["ts", "tsx"],
+  xml: ["html"],
+};
 
 export const plugins = [
   breaks(),
@@ -21,10 +30,13 @@ export const plugins = [
   mediumZoom(),
   gfm({ locale: gfm_zhHans }),
   highlightSSR({
+    aliases: highlightAliases,
+    detect: false,
     ignoreMissing: true,
-    languages: all,
+    plainText: ["text", "txt", "plain", "plaintext"],
   }),
-  codeBlockPlugin(), // 添加代码块插件来设置data-language属性
+  codeBlockPlugin(),
+  tablePlugin(),
   inlineCodePlugin(),
   prettyLinkPlugin(),
   headingPlugin(),

--- a/components/bytemd/markdown-enhancer.tsx
+++ b/components/bytemd/markdown-enhancer.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+
+import { bindCodeCopyButtons } from "./plugins/code-block";
+
+type MarkdownEnhancerProps = {
+  markdownBodyID: string;
+};
+
+export const MarkdownEnhancer = ({ markdownBodyID }: MarkdownEnhancerProps) => {
+  React.useEffect(() => {
+    const markdownBody = document.getElementById(markdownBodyID);
+    if (!markdownBody) {
+      return;
+    }
+
+    let mounted = true;
+    const cleanups: Array<() => void> = [bindCodeCopyButtons(markdownBody)];
+
+    void import("@bytemd/plugin-medium-zoom").then(
+      ({ default: mediumZoom }) => {
+        if (!mounted) {
+          return;
+        }
+
+        const cleanup = mediumZoom().viewerEffect?.({
+          file: undefined as never,
+          markdownBody,
+        });
+        if (typeof cleanup === "function") {
+          cleanups.push(cleanup);
+        }
+      },
+    );
+
+    return () => {
+      mounted = false;
+      cleanups.forEach((cleanup) => cleanup());
+    };
+  }, [markdownBodyID]);
+
+  return null;
+};

--- a/components/bytemd/plugins/code-block.ts
+++ b/components/bytemd/plugins/code-block.ts
@@ -1,10 +1,11 @@
 import type { BytemdPlugin } from "bytemd";
-import type { Element, Root } from "hast";
 import { visit } from "unist-util-visit";
 
 import { copyToClipboard, isBrowser } from "@/lib/utils";
 
 import {
+  type HastElement,
+  type HastRoot,
   cloneHastNode,
   createElementFromHtml,
   getClassNames,
@@ -21,6 +22,84 @@ ${copyIcon}
 
 const clipboardCheckIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m12 15 2 2 4-4"/><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
 
+const createLanguageLabelNode = (language: string): HastElement => ({
+  type: "element",
+  tagName: "span",
+  properties: {
+    ariaHidden: true,
+    className: ["code-block-language"],
+  },
+  children: [{ type: "text", value: language.toUpperCase() }],
+});
+
+const getCodeLanguage = (node: HastElement) => {
+  const languageClass = getClassNames(node.properties).find(
+    (className) =>
+      className.startsWith("language-") || className.startsWith("lang-"),
+  );
+
+  return languageClass?.replace(/^lang(uage)?-/, "")?.split(":")[0];
+};
+
+export const bindCodeCopyButtons = (markdownBody: HTMLElement) => {
+  const handleClick = (event: MouseEvent) => {
+    const target = event.target;
+    if (!(target instanceof globalThis.Element)) {
+      return;
+    }
+
+    const button = target.closest<HTMLButtonElement>(".copy-code-button");
+    if (!button || !markdownBody.contains(button)) {
+      return;
+    }
+
+    void (async () => {
+      const code = button.closest("pre")?.querySelector("code");
+      let codeText = code?.textContent ?? "";
+
+      if (codeText.startsWith("$")) {
+        codeText = codeText.slice(1).trim();
+      }
+
+      const copied = await copyToClipboard(codeText);
+      if (!copied) {
+        return;
+      }
+
+      const existingTimer = button.dataset.copyResetTimer;
+      if (existingTimer) {
+        window.clearTimeout(Number(existingTimer));
+      }
+
+      button.innerHTML = clipboardCheckIcon;
+      button.setAttribute("aria-label", "代码已复制");
+
+      const timer = window.setTimeout(() => {
+        button.innerHTML = copyIcon;
+        button.setAttribute("aria-label", "复制代码");
+        delete button.dataset.copyResetTimer;
+      }, 2 * 1000);
+
+      button.dataset.copyResetTimer = String(timer);
+    })();
+  };
+
+  markdownBody.addEventListener("click", handleClick);
+
+  return () => {
+    markdownBody.removeEventListener("click", handleClick);
+    markdownBody
+      .querySelectorAll<HTMLButtonElement>(".copy-code-button")
+      .forEach((button) => {
+        const existingTimer = button.dataset.copyResetTimer;
+        if (existingTimer) {
+          window.clearTimeout(Number(existingTimer));
+          delete button.dataset.copyResetTimer;
+        }
+      });
+  };
+};
+
 /**
  * 插件功能
  * 1. 显示代码类型
@@ -29,81 +108,39 @@ const clipboardCheckIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="1em" 
 export const codeBlockPlugin = (): BytemdPlugin => {
   return {
     rehype: (process) =>
-      process.use(() => (tree: Root) => {
-        visit(tree, "element", (node: Element) => {
+      process.use(() => (tree: HastRoot) => {
+        visit(tree, "element", (node: HastElement) => {
           if (node.tagName === "pre") {
-            // 添加复制按钮
-            node.children.push(cloneHastNode(copyButtonNode));
-
-            // 查找pre元素中的code子元素来提取语言信息
             const codeElement = node.children.find(
-              (child): child is Element =>
+              (child): child is HastElement =>
                 isElement(child) && child.tagName === "code",
             );
+            const language = codeElement ? getCodeLanguage(codeElement) : null;
 
-            if (codeElement) {
-              const languageClass = getClassNames(codeElement.properties).find(
-                (className) =>
-                  className.startsWith("language-") ||
-                  className.startsWith("lang-"),
-              );
-              const language = languageClass
-                ?.replace(/^lang(uage)?-/, "")
-                ?.split(":")[0];
+            node.properties ??= {};
+            node.properties.className = [
+              ...getClassNames(node.properties),
+              "markdown-code-block",
+            ];
 
-              if (language) {
-                // 确保properties对象存在
-                node.properties ??= {};
-                node.properties["data-language"] ??= language.toUpperCase();
-              }
+            const nextChildren = [...node.children];
+            if (language) {
+              node.properties["data-language"] = language.toUpperCase();
+              nextChildren.unshift(createLanguageLabelNode(language));
             }
+
+            nextChildren.push(cloneHastNode(copyButtonNode));
+            node.children = nextChildren;
           }
         });
       }),
 
     viewerEffect({ markdownBody }) {
-      // 针对 SSR 场景适配
       if (!isBrowser()) {
         return;
       }
 
-      const elements = markdownBody.querySelectorAll(".copy-code-button");
-      for (const element of elements) {
-        if (!(element instanceof HTMLElement)) {
-          continue;
-        }
-
-        if (element.dataset.copyBound === "true") {
-          continue;
-        }
-        element.dataset.copyBound = "true";
-
-        // 点击按钮复制代码到粘贴板
-        element.addEventListener("click", () => {
-          void (async () => {
-            const code = element.parentElement?.querySelector("code");
-            let codeText = code?.textContent ?? "";
-            // 复制代码时去除开头的$符号，然后trim一下，一般是复制shell命令的代码块会用到
-            if (codeText.startsWith("$")) {
-              codeText = codeText.slice(1).trim();
-            }
-            const copied = await copyToClipboard(codeText);
-            if (!copied) {
-              return;
-            }
-
-            const tmp = element.innerHTML;
-            element.innerHTML = clipboardCheckIcon;
-            element.setAttribute("aria-label", "代码已复制");
-
-            const timer = window.setTimeout(() => {
-              element.innerHTML = tmp;
-              element.setAttribute("aria-label", "复制代码");
-              window.clearTimeout(timer);
-            }, 3 * 1000);
-          })();
-        });
-      }
+      return bindCodeCopyButtons(markdownBody);
     },
   };
 };

--- a/components/bytemd/plugins/hast.ts
+++ b/components/bytemd/plugins/hast.ts
@@ -1,21 +1,54 @@
-import type { Element, RootContent, Text } from "hast";
 import { fromHtmlIsomorphic } from "hast-util-from-html-isomorphic";
 
-export const isElement = (node: unknown): node is Element =>
+export type HastProperties = Record<string, unknown>;
+
+export type HastText = {
+  type: "text";
+  value: string;
+};
+
+export type HastElement = {
+  type: "element";
+  tagName: string;
+  properties?: HastProperties;
+  children: HastNode[];
+};
+
+export type HastRoot = {
+  type: "root";
+  children: HastNode[];
+};
+
+export type HastNode =
+  | HastElement
+  | HastText
+  | {
+      type: string;
+      [key: string]: unknown;
+    };
+
+export type HastParent = {
+  children: HastNode[];
+};
+
+export const isElement = (node: unknown): node is HastElement =>
   typeof node === "object" &&
   node !== null &&
   (node as { type?: unknown }).type === "element";
 
-export const isText = (node: unknown): node is Text =>
+export const isText = (node: unknown): node is HastText =>
   typeof node === "object" &&
   node !== null &&
   (node as { type?: unknown }).type === "text" &&
   typeof (node as { value?: unknown }).value === "string";
 
-export const createElementFromHtml = (html: string): Element => {
-  const element = fromHtmlIsomorphic(html, { fragment: true }).children.find(
-    isElement,
-  ) as Element | undefined;
+export const createElementFromHtml = (html: string): HastElement => {
+  const fragment = fromHtmlIsomorphic(html, {
+    fragment: true,
+  }) as unknown as {
+    children: unknown[];
+  };
+  const element = fragment.children.find(isElement);
 
   if (!element) {
     throw new Error("Expected HTML fragment to contain an element");
@@ -24,18 +57,18 @@ export const createElementFromHtml = (html: string): Element => {
   return element;
 };
 
-export const cloneHastNode = <T extends RootContent>(node: T): T =>
-  JSON.parse(JSON.stringify(node)) as T;
+export const cloneHastNode = <T extends HastNode>(node: T): T =>
+  structuredClone(node);
 
 export const getStringProperty = (
-  properties: Element["properties"],
+  properties: HastElement["properties"],
   key: string,
 ) => {
   const value = properties?.[key];
   return typeof value === "string" ? value : undefined;
 };
 
-export const getClassNames = (properties: Element["properties"]) => {
+export const getClassNames = (properties: HastElement["properties"]) => {
   const value = properties?.className;
 
   if (Array.isArray(value)) {
@@ -49,7 +82,7 @@ export const getClassNames = (properties: Element["properties"]) => {
   return [];
 };
 
-export const appendClassName = (node: Element, className: string) => {
+export const appendClassName = (node: HastElement, className: string) => {
   node.properties ??= {};
   const classNames = getClassNames(node.properties);
 

--- a/components/bytemd/plugins/index.ts
+++ b/components/bytemd/plugins/index.ts
@@ -5,3 +5,5 @@ export * from "./code-block";
 export * from "./heading";
 
 export * from "./inline-code";
+
+export * from "./table";

--- a/components/bytemd/plugins/inline-code.ts
+++ b/components/bytemd/plugins/inline-code.ts
@@ -1,8 +1,13 @@
 import type { BytemdPlugin } from "bytemd";
-import type { Element, Root } from "hast";
 import { visit } from "unist-util-visit";
 
-import { appendClassName, isElement, isText } from "./hast";
+import {
+  type HastElement,
+  type HastRoot,
+  appendClassName,
+  isElement,
+  isText,
+} from "./hast";
 
 /**
  * Plugin to handle inline code display
@@ -12,8 +17,8 @@ import { appendClassName, isElement, isText } from "./hast";
 export const inlineCodePlugin = (): BytemdPlugin => {
   return {
     rehype: (process) =>
-      process.use(() => (tree: Root) => {
-        visit(tree, "element", (node: Element, _index, parent) => {
+      process.use(() => (tree: HastRoot) => {
+        visit(tree, "element", (node: HastElement, _index, parent) => {
           // Handle inline code elements (not in pre blocks)
           if (
             node.tagName === "code" &&

--- a/components/bytemd/plugins/pretty-link.ts
+++ b/components/bytemd/plugins/pretty-link.ts
@@ -1,10 +1,11 @@
 import type { BytemdPlugin } from "bytemd";
-import type { Element, Root } from "hast";
 import { visit } from "unist-util-visit";
 
 import { extractDomainFromUrl } from "@/utils";
 
 import {
+  type HastElement,
+  type HastRoot,
   cloneHastNode,
   createElementFromHtml,
   getStringProperty,
@@ -35,7 +36,7 @@ const stackoverflowSvgNode = createElementFromHtml(
   `<svg xmlns="http://www.w3.org/2000/svg" width="0.68em" height="0.8em" viewBox="0 0 256 304"><path fill="#bcbbbb" d="M216.33 276.188v-81.211h26.953v108.165H0V194.977h26.954v81.211z"/><path fill="#f48023" d="m56.708 187.276l132.318 27.654l5.6-26.604L62.31 160.672zm17.502-63.009l122.517 57.058l11.202-24.503L85.412 99.414zm33.955-60.208l103.964 86.462l17.152-20.653l-103.964-86.462zM175.375 0L153.67 16.102l80.511 108.515l21.703-16.102zM53.906 248.884h135.119V221.93H53.907z"/></svg>`,
 );
 
-const domainToSvgNodeMap: Record<string, Element> = {
+const domainToSvgNodeMap: Record<string, HastElement> = {
   "bilibili.com": bilibiliSvgNode,
   "juejin.cn": juejinSvgNode,
   "github.com": githubSvgNode,
@@ -62,8 +63,8 @@ const getExternalDomain = (href: string) => {
 export const prettyLinkPlugin = (): BytemdPlugin => {
   return {
     rehype: (process) =>
-      process.use(() => (tree: Root) => {
-        visit(tree, "element", (node: Element) => {
+      process.use(() => (tree: HastRoot) => {
+        visit(tree, "element", (node: HastElement) => {
           if (node.tagName === "a") {
             const href = getStringProperty(node.properties, "href");
             // 如果是以 # 开头，说明是hash，不做处理

--- a/components/bytemd/plugins/table.ts
+++ b/components/bytemd/plugins/table.ts
@@ -1,0 +1,51 @@
+import type { BytemdPlugin } from "bytemd";
+import { visit } from "unist-util-visit";
+
+import {
+  type HastElement,
+  type HastParent,
+  type HastRoot,
+  getClassNames,
+  isElement,
+} from "./hast";
+
+const TABLE_WRAPPER_CLASS = "markdown-table-wrapper";
+
+const createTableWrapper = (table: HastElement): HastElement => ({
+  type: "element",
+  tagName: "div",
+  properties: {
+    className: [TABLE_WRAPPER_CLASS],
+    role: "region",
+    tabIndex: 0,
+  },
+  children: [table],
+});
+
+const hasTableWrapper = (parent: HastParent | undefined) => {
+  return (
+    isElement(parent) &&
+    parent.tagName === "div" &&
+    getClassNames(parent.properties).includes(TABLE_WRAPPER_CLASS)
+  );
+};
+
+export const tablePlugin = (): BytemdPlugin => {
+  return {
+    rehype: (processor) =>
+      processor.use(() => (tree: HastRoot) => {
+        visit(tree, "element", (node: HastElement, index, parent) => {
+          if (
+            node.tagName !== "table" ||
+            typeof index !== "number" ||
+            !parent ||
+            hasTableWrapper(parent)
+          ) {
+            return;
+          }
+
+          parent.children[index] = createTableWrapper(node);
+        });
+      }),
+  };
+};

--- a/components/bytemd/render-markdown.ts
+++ b/components/bytemd/render-markdown.ts
@@ -1,0 +1,69 @@
+import { cache } from "react";
+
+import { type BytemdPlugin, getProcessor } from "bytemd";
+import { visit } from "unist-util-visit";
+
+import { type OptionItem } from "@/types";
+
+import { plugins, sanitize } from "./config";
+import {
+  type HastElement,
+  type HastRoot,
+  getStringProperty,
+  isElement,
+  isText,
+} from "./plugins/hast";
+
+type RenderedMarkdown = {
+  html: string;
+  toc: OptionItem<string>[];
+};
+
+const getTextContent = (node: HastElement): string => {
+  return node.children
+    .map((child) => {
+      if (isText(child)) {
+        return child.value;
+      }
+
+      if (isElement(child)) {
+        return getTextContent(child);
+      }
+
+      return "";
+    })
+    .join("")
+    .trim();
+};
+
+const createTocPlugin = (toc: OptionItem<string>[]): BytemdPlugin => ({
+  rehype: (processor) =>
+    processor.use(() => (tree: HastRoot) => {
+      visit(tree, "element", (node: HastElement) => {
+        if (node.tagName !== "h2") {
+          return;
+        }
+
+        const id = getStringProperty(node.properties, "id");
+        const label = getTextContent(node);
+        if (!id || !label) {
+          return;
+        }
+
+        toc.push({ label, value: id });
+      });
+    }),
+});
+
+export const renderMarkdown = cache((body: string): RenderedMarkdown => {
+  const toc: OptionItem<string>[] = [];
+  const file = getProcessor({
+    plugins: [...plugins, createTocPlugin(toc)],
+    sanitize,
+  }).processSync(body);
+
+  return {
+    html: file.toString(),
+    toc,
+  };
+});

--- a/components/markdown-toc/index.tsx
+++ b/components/markdown-toc/index.tsx
@@ -1,37 +1,14 @@
-"use client";
-
 import React from "react";
 
 import Link from "next/link";
 
-import { useMount } from "ahooks";
-
 import { type OptionItem } from "@/types";
 
-export const MarkdownTOC = () => {
-  const [tocList, setTocList] = React.useState<OptionItem<string>[]>([]);
+type MarkdownTOCProps = {
+  tocList: OptionItem<string>[];
+};
 
-  useMount(() => {
-    const markdownBodyElement = document.querySelector(".markdown-body");
-    if (!markdownBodyElement) return;
-
-    const h2Elems = markdownBodyElement.querySelectorAll("h2");
-    const newTocList: OptionItem<string>[] = [];
-
-    h2Elems.forEach((h2) => {
-      const text = h2.textContent;
-      const id = h2.getAttribute("id");
-      if (text && id) {
-        newTocList.push({
-          value: id,
-          label: text,
-        });
-      }
-    });
-
-    setTocList(newTocList);
-  });
-
+export const MarkdownTOC = ({ tocList }: MarkdownTOCProps) => {
   return (
     <div>
       <div className="future-label">Contents</div>

--- a/components/motion/gsap-reveal.tsx
+++ b/components/motion/gsap-reveal.tsx
@@ -26,18 +26,27 @@ export const GsapReveal = ({
 
   useGSAP(
     () => {
-      const items = gsap.utils.toArray<HTMLElement>(selector);
+      const root = scope.current;
+      const items = root
+        ? gsap.utils.toArray<HTMLElement>(root.querySelectorAll(selector))
+        : [];
 
       if (!items.length) {
         return;
       }
+
+      const clearRevealStyles = () => {
+        gsap.set(items, {
+          clearProps: "opacity,visibility,transform,filter",
+        });
+      };
 
       const reduceMotion = window.matchMedia(
         "(prefers-reduced-motion: reduce)",
       ).matches;
 
       if (reduceMotion) {
-        gsap.set(items, { autoAlpha: 1, clearProps: "transform,filter" });
+        clearRevealStyles();
         return;
       }
 
@@ -56,6 +65,11 @@ export const GsapReveal = ({
             duration: 0.9,
             delay: Math.min(index * stagger, 0.32),
             ease: "power3.out",
+            onComplete: () => {
+              gsap.set(item, {
+                clearProps: "opacity,visibility,transform,filter",
+              });
+            },
             scrollTrigger: {
               trigger: item,
               start: "top 88%",
@@ -64,6 +78,9 @@ export const GsapReveal = ({
           },
         );
       });
+
+      gsap.delayedCall(1.6, clearRevealStyles);
+      requestAnimationFrame(() => ScrollTrigger.refresh());
     },
     { scope },
   );

--- a/features/blog/pages/blog-detail-page.tsx
+++ b/features/blog/pages/blog-detail-page.tsx
@@ -4,7 +4,9 @@ import Link from "next/link";
 
 import { CalendarDays, Eye, MapPin, MoveLeft, User } from "lucide-react";
 
-import { BytemdViewer } from "@/components/bytemd";
+import { type OptionItem } from "@/types";
+
+import { MarkdownEnhancer } from "@/components/bytemd/markdown-enhancer";
 import { DetailSidebar } from "@/components/detail-sidebar";
 import { MarkdownTOC } from "@/components/markdown-toc";
 import { GsapReveal } from "@/components/motion/gsap-reveal";
@@ -21,10 +23,16 @@ import { type Blog } from "../types";
 
 type BlogDetailProps = {
   blog: Blog;
+  markdown: {
+    html: string;
+    toc: OptionItem<string>[];
+  };
   uv?: number;
 };
 
-export const BlogDetailPage = ({ blog, uv = 0 }: BlogDetailProps) => {
+export const BlogDetailPage = ({ blog, markdown, uv = 0 }: BlogDetailProps) => {
+  const markdownBodyID = `blog-markdown-${blog.id}`;
+
   return (
     <Wrapper className="flex flex-col px-6 pb-24 pt-8">
       <ArticleReadingProgress />
@@ -103,7 +111,12 @@ export const BlogDetailPage = ({ blog, uv = 0 }: BlogDetailProps) => {
           className="mt-8 grid gap-8 wrapper:grid-cols-[minmax(0,1fr)_240px]"
         >
           <article className="future-panel-strong overflow-hidden rounded-[2rem] px-5 py-7 md:p-10">
-            <BytemdViewer body={blog.body || ""} />
+            <div
+              id={markdownBodyID}
+              className="markdown-body"
+              dangerouslySetInnerHTML={{ __html: markdown.html }}
+            />
+            <MarkdownEnhancer markdownBodyID={markdownBodyID} />
 
             <div className="mt-12 border-t border-[var(--future-line)] pt-8">
               <p className="future-label mb-4">Tagged</p>
@@ -112,7 +125,7 @@ export const BlogDetailPage = ({ blog, uv = 0 }: BlogDetailProps) => {
           </article>
 
           <DetailSidebar>
-            <MarkdownTOC />
+            <MarkdownTOC tocList={markdown.toc} />
           </DetailSidebar>
         </div>
       </GsapReveal>

--- a/styles/bytemd.css
+++ b/styles/bytemd.css
@@ -1,462 +1,71 @@
-/* 创建、编辑笔记的编辑器高度 */
+/* ByteMD editor sizing */
 #note-editor .bytemd {
   @apply h-[60vh] min-h-[560px];
 }
-/* 创建、编辑博客的编辑器高度 */
+
 #content-editor .bytemd {
   @apply h-screen;
 }
-/* 编辑器编辑区域的最大宽度 */
+
 .bytemd-editor .CodeMirror .CodeMirror-lines {
   @apply !max-w-[80vw];
 }
+
 .bytemd .CodeMirror,
 .bytemd code,
 .bytemd kbd {
   @apply !font-mono;
 }
+
 .bytemd-fullscreen {
   @apply !z-10 !h-screen;
 }
+
+/* Shared Markdown surface */
 .markdown-body {
   @apply prose prose-neutral !w-full !max-w-full dark:prose-invert;
-}
-.markdown-body a {
-  @apply mx-1 inline-flex items-center gap-1 !no-underline;
-}
-.medium-zoom-image--opened {
-  @apply z-30;
-}
-.medium-zoom-overlay {
-  @apply z-20 !bg-background;
-}
-.markdown-body code::-webkit-scrollbar {
-  @apply h-1.5 w-1.5;
-}
-.markdown-body code::-webkit-scrollbar-thumb {
-  background: hsl(var(--foreground) / 0.2);
-  /* 滚动条圆角 需要同时设置 background-clip: padding-box;和border-radius */
-  background-clip: padding-box;
-  border-radius: 10px;
-}
-/* Minimal inline code styling - no background, no borders */
-.markdown-body p code,
-.markdown-body li code,
-.markdown-body td code,
-.markdown-body th code,
-.markdown-body h1 code,
-.markdown-body h2 code,
-.markdown-body h3 code,
-.markdown-body h4 code,
-.markdown-body h5 code,
-.markdown-body h6 code,
-.inline-code-enhanced {
-  @apply font-mono;
-  background: transparent;
-  border: none;
-  color: #d73a49;
-  font-weight: 600;
-  font-size: 0.9em;
-  padding: 0;
-  margin: 0;
-  box-shadow: none;
-  border-radius: 0;
-  display: inline;
-  transition: color 0.2s ease;
-}
-
-/* Hide the backticks by overriding content */
-.markdown-body p code::before,
-.markdown-body li code::before,
-.markdown-body td code::before,
-.markdown-body th code::before,
-.markdown-body h1 code::before,
-.markdown-body h2 code::before,
-.markdown-body h3 code::before,
-.markdown-body h4 code::before,
-.markdown-body h5 code::before,
-.markdown-body h6 code::before {
-  content: "";
-}
-
-.markdown-body p code::after,
-.markdown-body li code::after,
-.markdown-body td code::after,
-.markdown-body th code::after,
-.markdown-body h1 code::after,
-.markdown-body h2 code::after,
-.markdown-body h3 code::after,
-.markdown-body h4 code::after,
-.markdown-body h5 code::after,
-.markdown-body h6 code::after {
-  content: "";
-}
-
-/* Dark theme inline code */
-.dark .markdown-body p code,
-.dark .markdown-body li code,
-.dark .markdown-body td code,
-.dark .markdown-body th code,
-.dark .markdown-body h1 code,
-.dark .markdown-body h2 code,
-.dark .markdown-body h3 code,
-.dark .markdown-body h4 code,
-.dark .markdown-body h5 code,
-.dark .markdown-body h6 code,
-.dark .inline-code-enhanced {
-  background: transparent;
-  border: none;
-  color: #f97316;
-  box-shadow: none;
-}
-
-/* Subtle hover effect for inline code */
-.markdown-body p code:hover,
-.markdown-body li code:hover,
-.markdown-body td code:hover,
-.markdown-body th code:hover,
-.markdown-body h1 code:hover,
-.markdown-body h2 code:hover,
-.markdown-body h3 code:hover,
-.markdown-body h4 code:hover,
-.markdown-body h5 code:hover,
-.markdown-body h6 code:hover,
-.inline-code-enhanced:hover {
-  color: #c8384a;
-}
-
-.dark .markdown-body p code:hover,
-.dark .markdown-body li code:hover,
-.dark .markdown-body td code:hover,
-.dark .markdown-body th code:hover,
-.dark .markdown-body h1 code:hover,
-.dark .markdown-body h2 code:hover,
-.dark .markdown-body h3 code:hover,
-.dark .markdown-body h4 code:hover,
-.dark .markdown-body h5 code:hover,
-.dark .markdown-body h6 code:hover,
-.dark .inline-code-enhanced:hover {
-  color: #fb923c;
-}
-
-/* Blog code blocks */
-.markdown-body {
-  --markdown-code-bg: #090b10;
-  --markdown-code-bg-soft: #111722;
-  --markdown-code-border: rgb(148 163 184 / 0.24);
-  --markdown-code-header: rgb(255 255 255 / 0.07);
-  --markdown-code-text: #e8edf5;
-  --markdown-code-muted: rgb(226 232 240 / 0.64);
-  --markdown-code-accent: #22d3ee;
+  --markdown-surface: hsl(var(--card) / 0.72);
+  --markdown-surface-strong: hsl(var(--muted) / 0.72);
+  --markdown-line: hsl(var(--border));
+  --markdown-ink: hsl(var(--foreground));
+  --markdown-muted: hsl(var(--muted-foreground));
+  --markdown-accent: hsl(var(--primary));
+  --markdown-accent-soft: hsl(var(--primary) / 0.1);
+  --markdown-code-bg: #0d1117;
+  --markdown-code-header: #161b22;
+  --markdown-code-line: rgb(139 148 158 / 0.26);
+  --markdown-code-text: #e6edf3;
+  --markdown-code-muted: #8b949e;
   --markdown-code-shadow:
-    0 24px 70px rgb(15 23 42 / 0.22), inset 0 1px 0 rgb(255 255 255 / 0.08);
+    0 18px 48px rgb(15 23 42 / 0.16), inset 0 1px 0 rgb(255 255 255 / 0.04);
+  color: var(--markdown-ink);
+  overflow-wrap: break-word;
+  text-rendering: optimizeLegibility;
 }
 
 .dark .markdown-body {
-  --markdown-code-bg: #07080d;
-  --markdown-code-bg-soft: #10141d;
-  --markdown-code-border: rgb(255 255 255 / 0.14);
-  --markdown-code-header: rgb(255 255 255 / 0.065);
-  --markdown-code-text: #eef2f8;
-  --markdown-code-muted: rgb(226 232 240 / 0.6);
+  --markdown-surface: rgb(255 255 255 / 0.045);
+  --markdown-surface-strong: rgb(255 255 255 / 0.07);
+  --markdown-line: rgb(255 255 255 / 0.13);
+  --markdown-code-bg: #0d1117;
+  --markdown-code-header: #161b22;
+  --markdown-code-line: rgb(240 246 252 / 0.14);
   --markdown-code-shadow:
-    0 24px 80px rgb(0 0 0 / 0.36), inset 0 1px 0 rgb(255 255 255 / 0.08);
+    0 18px 52px rgb(0 0 0 / 0.32), inset 0 1px 0 rgb(255 255 255 / 0.05);
 }
 
-.markdown-body pre {
-  position: relative;
-  margin: 2rem 0;
-  border: 1px solid var(--markdown-code-border);
-  border-radius: 1rem;
-  background:
-    radial-gradient(
-      circle at 14% 0%,
-      color-mix(in srgb, var(--markdown-code-accent) 22%, transparent),
-      transparent 18rem
-    ),
-    linear-gradient(
-      145deg,
-      var(--markdown-code-bg-soft),
-      var(--markdown-code-bg) 58%
-    );
-  box-shadow: var(--markdown-code-shadow);
-  color: var(--markdown-code-text);
-  overflow: hidden;
-}
-
-.markdown-body pre::before {
-  content: "";
-  position: absolute;
-  inset: 0 0 auto;
-  height: 3.25rem;
-  border-bottom: 1px solid var(--markdown-code-border);
-  background:
-    linear-gradient(90deg, rgb(255 255 255 / 0.08), transparent 52%),
-    var(--markdown-code-header);
-  pointer-events: none;
-}
-
-.markdown-body pre[data-language]::after {
-  content: attr(data-language);
-  position: absolute;
-  top: 0.95rem;
-  left: 1rem;
-  right: 4rem;
-  z-index: 1;
-  overflow: hidden;
-  color: var(--markdown-code-muted);
-  font-family:
-    "SF Mono", "Monaco", "Menlo", "Consolas", "Courier New", monospace;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  line-height: 1;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.markdown-body pre > code,
-.markdown-body pre > code.hljs {
-  display: block;
-  min-width: 0;
-  max-width: 100%;
-  overflow-x: auto;
-  padding: 4.35rem 1.25rem 1.25rem;
-  background: transparent !important;
-  color: var(--markdown-code-text);
-  font-family:
-    "SF Mono", "Monaco", "Menlo", "Consolas", "Courier New", monospace;
-  font-size: 0.86rem;
-  line-height: 1.78;
-  scrollbar-color: color-mix(
-      in srgb,
-      var(--markdown-code-accent) 46%,
-      transparent
-    )
-    transparent;
-  scrollbar-width: thin;
-  white-space: pre;
-}
-
-.markdown-body pre > .copy-code-button {
-  position: absolute;
-  top: 0.62rem;
-  right: 0.75rem;
-  z-index: 2;
-  display: inline-flex;
-  width: 2rem;
-  height: 2rem;
-  cursor: pointer;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--markdown-code-border);
-  border-radius: 0.68rem;
-  background: rgb(255 255 255 / 0.08);
-  color: var(--markdown-code-text);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.08);
-  transition:
-    background-color 160ms ease,
-    border-color 160ms ease,
-    color 160ms ease,
-    transform 160ms ease;
-}
-
-.markdown-body pre > .copy-code-button:hover {
-  border-color: color-mix(
-    in srgb,
-    var(--markdown-code-accent) 52%,
-    var(--markdown-code-border)
-  );
-  background: color-mix(
-    in srgb,
-    var(--markdown-code-accent) 16%,
-    rgb(255 255 255 / 0.08)
-  );
-  color: white;
-  transform: translateY(-1px);
-}
-
-.markdown-body pre > .copy-code-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--markdown-code-accent) 74%, white);
-  outline-offset: 2px;
-}
-
-.markdown-body pre > .copy-code-button svg {
-  width: 1rem;
-  height: 1rem;
-}
-
-.markdown-body pre > code::-webkit-scrollbar {
-  height: 0.55rem;
-}
-
-.markdown-body pre > code::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.markdown-body pre > code::-webkit-scrollbar-thumb {
-  border: 0.18rem solid transparent;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--markdown-code-accent) 42%, transparent);
-  background-clip: padding-box;
-}
-
-.markdown-body pre code::selection {
-  background: color-mix(in srgb, var(--markdown-code-accent) 26%, transparent);
-  color: inherit;
-}
-
-.markdown-body pre .hljs,
-.markdown-body pre .hljs-subst {
-  color: var(--markdown-code-text);
-}
-
-.markdown-body pre .hljs-comment,
-.markdown-body pre .hljs-quote {
-  color: #7c8da6;
-  font-style: italic;
-}
-
-.markdown-body pre .hljs-keyword,
-.markdown-body pre .hljs-selector-tag,
-.markdown-body pre .hljs-literal,
-.markdown-body pre .hljs-section,
-.markdown-body pre .hljs-link,
-.markdown-body pre .hljs-type {
-  color: #ff8a8a;
-  font-weight: 700;
-}
-
-.markdown-body pre .hljs-title,
-.markdown-body pre .hljs-title.class_,
-.markdown-body pre .hljs-title.function_ {
-  color: #f7c873;
-}
-
-.markdown-body pre .hljs-string,
-.markdown-body pre .hljs-regexp,
-.markdown-body pre .hljs-symbol,
-.markdown-body pre .hljs-bullet {
-  color: #9ae6b4;
-}
-
-.markdown-body pre .hljs-attr,
-.markdown-body pre .hljs-attribute,
-.markdown-body pre .hljs-name,
-.markdown-body pre .hljs-variable,
-.markdown-body pre .hljs-template-variable,
-.markdown-body pre .hljs-selector-class,
-.markdown-body pre .hljs-selector-id {
-  color: #7dd3fc;
-}
-
-.markdown-body pre .hljs-number,
-.markdown-body pre .hljs-meta,
-.markdown-body pre .hljs-built_in,
-.markdown-body pre .hljs-operator {
-  color: #c4b5fd;
-}
-
-.markdown-body pre .hljs-addition {
-  color: #86efac;
-  background: rgb(22 101 52 / 0.22);
-}
-
-.markdown-body pre .hljs-deletion {
-  color: #fca5a5;
-  background: rgb(153 27 27 / 0.22);
-}
-
-@media (max-width: 768px) {
-  .markdown-body pre {
-    margin-left: -0.25rem;
-    margin-right: -0.25rem;
-    border-radius: 0.9rem;
-  }
-
-  .markdown-body pre[data-language]::after {
-    left: 0.9rem;
-    right: 3.45rem;
-    font-size: 0.66rem;
-  }
-
-  .markdown-body pre > code,
-  .markdown-body pre > code.hljs {
-    padding: 4rem 1rem 1.05rem;
-    font-size: 0.78rem;
-    line-height: 1.72;
-  }
-
-  .markdown-body pre > .copy-code-button {
-    right: 0.62rem;
-    width: 1.85rem;
-    height: 1.85rem;
-  }
-}
-.markdown-body iframe {
-  @apply aspect-video w-full;
-}
-.markdown-body :where(h2, h3, h4, h5, h6) {
-  @apply flex scroll-mt-20 items-center;
-}
-.markdown-body :where(h2, h3, h4, h5, h6):hover .markdown-anchor {
-  @apply opacity-100;
-}
-.markdown-body :where(h2, h3, h4, h5, h6) .markdown-anchor {
-  @apply order-2 opacity-0 transition-opacity;
-}
-.markdown-body img {
-  @apply mx-auto max-h-[40vh] rounded-lg border p-4;
-}
-/* 修复存在表格时，表格宽度溢出的问题 */
-.markdown-body table thead th {
-  @apply break-all;
-}
-/* 编辑器内标题样式 */
-.cm-header {
-  @apply !text-[#005cc5] dark:!text-[#79b8ff];
-}
-/* 编辑器内列表项样式 */
-.cm-variable-2 {
-  @apply !text-[#24292e] dark:!text-[#e1e4e8];
-}
-/* 编辑器内代码块样式 */
-.cm-comment {
-  @apply !text-[#032f62] dark:!text-[#9ecbff];
-}
-/* 编辑器内引用样式 */
-.cm-quote {
-  @apply !text-[#22863a] dark:!text-[#85e89d];
-}
-/* 编辑器内链接样式 */
-.cm-link {
-  @apply !text-[#22863a] dark:!text-[#85e89d];
-}
-/* 编辑器内图片链接样式 */
-.cm-string {
-  @apply !break-all !text-[#24292e] dark:!text-[#e1e4e8];
-}
-/* 编辑器内光标颜色 */
-.CodeMirror-cursor {
-  @apply !border-l-2 !border-l-[#204085] dark:!border-l-[#cee0fd];
-}
-/* 编辑器内显示行数 */
-.CodeMirror-linenumber {
-  @apply !text-foreground;
-}
-/* 编辑器内显示行数背景 */
-.CodeMirror-gutters {
-  @apply !border-r-muted !bg-background;
-}
-
-/* Public blog reading surface */
 .future-site .markdown-body {
   @apply !max-w-none;
-  --markdown-code-bg: #08090c;
-  --markdown-code-bg-soft: #11131a;
-  --markdown-code-border: var(--future-line);
-  --markdown-code-header: rgb(255 255 255 / 0.065);
-  --markdown-code-accent: var(--future-cyan);
+  --markdown-surface: var(--future-panel);
+  --markdown-surface-strong: var(--future-panel-strong);
+  --markdown-line: var(--future-line);
+  --markdown-ink: var(--future-ink);
+  --markdown-muted: var(--future-muted);
+  --markdown-accent: var(--future-accent);
+  --markdown-accent-soft: var(--future-accent-soft);
+  --markdown-code-bg: #0d1117;
+  --markdown-code-header: #161b22;
+  --markdown-code-line: rgb(240 246 252 / 0.13);
   --markdown-code-shadow: var(--future-shadow), var(--future-inner);
   color: var(--future-ink);
   font-family:
@@ -465,7 +74,6 @@
   font-size: 1.0625rem;
   letter-spacing: 0;
   line-height: 1.92;
-  text-rendering: optimizeLegibility;
 }
 
 .future-site .markdown-body p,
@@ -479,24 +87,53 @@
   font-weight: 700;
 }
 
-.future-site .markdown-body a {
-  color: var(--future-cyan);
-  text-decoration: none !important;
+.markdown-body a {
+  @apply inline-flex items-center gap-1 !no-underline;
+  color: var(--markdown-accent);
   border-bottom: 1px solid
-    color-mix(in srgb, var(--future-cyan) 42%, transparent);
+    color-mix(in srgb, var(--markdown-accent) 36%, transparent);
+  text-underline-offset: 0.18em;
+}
+
+.markdown-body a:hover {
+  border-color: color-mix(in srgb, var(--markdown-accent) 72%, transparent);
+}
+
+.medium-zoom-image--opened {
+  @apply z-30;
+}
+
+.medium-zoom-overlay {
+  @apply z-20 !bg-background;
+}
+
+.markdown-body iframe {
+  @apply aspect-video w-full;
+}
+
+.markdown-body :where(h2, h3, h4, h5, h6) {
+  @apply flex scroll-mt-20 items-center;
+  color: var(--markdown-ink);
+  letter-spacing: 0;
+  text-wrap: balance;
 }
 
 .future-site .markdown-body :where(h2, h3, h4, h5, h6) {
   @apply scroll-mt-28;
-  color: var(--future-ink);
-  letter-spacing: 0;
-  text-wrap: balance;
+}
+
+.markdown-body :where(h2, h3, h4, h5, h6):hover .markdown-anchor {
+  @apply opacity-100;
+}
+
+.markdown-body :where(h2, h3, h4, h5, h6) .markdown-anchor {
+  @apply order-2 opacity-0 transition-opacity;
 }
 
 .future-site .markdown-body h2 {
   margin-top: 3.2rem;
   padding-top: 1.35rem;
-  border-top: 1px solid var(--future-line);
+  border-top: 1px solid var(--markdown-line);
   font-size: 2.35rem;
   line-height: 1.18;
 }
@@ -513,20 +150,19 @@
   line-height: 1.38;
 }
 
+.markdown-body blockquote {
+  border-color: var(--markdown-accent);
+  color: var(--markdown-ink);
+}
+
 .future-site .markdown-body blockquote {
   margin: 2.5rem 0;
   border-left: 3px solid var(--future-accent);
-  border-radius: 0 1.35rem 1.35rem 0;
-  background: linear-gradient(
-    90deg,
-    color-mix(in srgb, var(--future-accent) 13%, var(--future-panel)),
-    var(--future-panel)
-  );
+  border-radius: 0 0.75rem 0.75rem 0;
+  background: color-mix(in srgb, var(--future-accent) 10%, var(--future-panel));
   box-shadow: var(--future-inner);
   padding: 1.2rem 1.4rem;
   color: var(--future-ink);
-  -webkit-backdrop-filter: blur(20px) saturate(1.2);
-  backdrop-filter: blur(20px) saturate(1.2);
 }
 
 .future-site .markdown-body blockquote p {
@@ -540,52 +176,301 @@
   background: linear-gradient(
     90deg,
     transparent,
-    var(--future-line),
+    var(--markdown-line),
     transparent
   );
   margin: 3.5rem 0;
 }
 
+.markdown-body img {
+  @apply mx-auto max-h-[40vh] rounded-lg border p-4;
+}
+
 .future-site .markdown-body img {
-  @apply max-h-none rounded-[1.5rem] p-0;
-  border: 1px solid var(--future-line);
-  background: var(--future-panel);
+  @apply max-h-none rounded-xl p-0;
+  border: 1px solid var(--markdown-line);
+  background: var(--markdown-surface);
   box-shadow: var(--future-shadow);
 }
 
-.future-site .markdown-body table {
-  display: block;
-  width: 100%;
+/* Inline code */
+.markdown-body code::before,
+.markdown-body code::after {
+  content: none;
+}
+
+.markdown-body :where(p, li, td, th, h1, h2, h3, h4, h5, h6) code,
+.markdown-body code.inline-code-enhanced {
+  @apply font-mono;
+  display: inline;
+  box-decoration-break: clone;
+  border: 1px solid color-mix(in srgb, var(--markdown-accent) 24%, transparent);
+  border-radius: 0.375rem;
+  background: var(--markdown-accent-soft);
+  color: var(--markdown-accent);
+  font-size: 0.88em;
+  font-weight: 650;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0.08rem 0.32rem;
+  white-space: break-spaces;
+}
+
+.markdown-body :where(p, li, td, th, h1, h2, h3, h4, h5, h6) code:hover,
+.markdown-body code.inline-code-enhanced:hover {
+  background: color-mix(in srgb, var(--markdown-accent) 15%, transparent);
+}
+
+/* Code blocks */
+.markdown-body pre {
+  position: relative;
+  margin: 1.75rem 0;
+  padding: 0;
   overflow: hidden;
-  border: 1px solid var(--future-line);
-  border-radius: 1rem;
-  background: var(--future-panel);
-  box-shadow: var(--future-inner);
-  overflow-x: auto;
+  border: 1px solid var(--markdown-code-line);
+  border-radius: 0.75rem;
+  background: var(--markdown-code-bg);
+  box-shadow: var(--markdown-code-shadow);
+  color: var(--markdown-code-text);
+}
+
+.markdown-body pre::before {
+  content: "";
+  display: block;
+  height: 2.75rem;
+  border-bottom: 1px solid var(--markdown-code-line);
+  background: var(--markdown-code-header);
+}
+
+.markdown-body pre > .code-block-language {
+  position: absolute;
+  top: 0.95rem;
+  left: 1rem;
+  right: 3.75rem;
+  z-index: 1;
+  overflow: hidden;
+  color: var(--markdown-code-muted);
+  font-family:
+    "SF Mono", "Monaco", "Menlo", "Consolas", "Courier New", monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.future-site .markdown-body table th,
-.future-site .markdown-body table td {
-  border-color: var(--future-line);
+.markdown-body pre > code,
+.markdown-body pre > code.hljs {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  overflow-x: auto;
+  background: transparent !important;
+  color: var(--markdown-code-text);
+  font-family:
+    "SF Mono", "Monaco", "Menlo", "Consolas", "Courier New", monospace;
+  font-size: 0.875rem;
+  line-height: 1.72;
+  padding: 1rem 1.125rem 1.125rem;
+  scrollbar-color: color-mix(in srgb, var(--markdown-accent) 46%, transparent)
+    transparent;
+  scrollbar-width: thin;
+  white-space: pre;
 }
 
-.future-site .markdown-body table th {
-  color: var(--future-ink);
-  background: color-mix(in srgb, var(--future-accent) 14%, transparent);
+.markdown-body pre > .copy-code-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.62rem;
+  z-index: 2;
+  display: inline-flex;
+  width: 1.85rem;
+  height: 1.85rem;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--markdown-code-line);
+  border-radius: 0.5rem;
+  background: rgb(255 255 255 / 0.06);
+  color: var(--markdown-code-text);
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
 }
 
-.future-site .markdown-body p code,
-.future-site .markdown-body li code,
-.future-site .markdown-body td code,
-.future-site .markdown-body th code,
-.future-site .inline-code-enhanced {
-  border: 1px solid color-mix(in srgb, var(--future-accent) 24%, transparent);
-  border-radius: 0.45rem;
-  background: color-mix(in srgb, var(--future-accent) 10%, transparent);
-  color: var(--future-accent);
+.markdown-body pre > .copy-code-button:hover {
+  border-color: color-mix(in srgb, var(--markdown-accent) 48%, white);
+  background: color-mix(in srgb, var(--markdown-accent) 15%, transparent);
+  color: white;
+}
+
+.markdown-body pre > .copy-code-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--markdown-accent) 72%, white);
+  outline-offset: 2px;
+}
+
+.markdown-body pre > .copy-code-button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.markdown-body code::-webkit-scrollbar,
+.markdown-table-wrapper::-webkit-scrollbar {
+  width: 0.55rem;
+  height: 0.55rem;
+}
+
+.markdown-body code::-webkit-scrollbar-track,
+.markdown-table-wrapper::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.markdown-body code::-webkit-scrollbar-thumb,
+.markdown-table-wrapper::-webkit-scrollbar-thumb {
+  border: 0.18rem solid transparent;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--markdown-accent) 38%, transparent);
+  background-clip: padding-box;
+}
+
+.markdown-body pre code::selection {
+  background: color-mix(in srgb, var(--markdown-accent) 28%, transparent);
+  color: inherit;
+}
+
+.markdown-body pre .hljs,
+.markdown-body pre .hljs-subst {
+  color: var(--markdown-code-text);
+}
+
+.markdown-body pre .hljs-comment,
+.markdown-body pre .hljs-quote {
+  color: #8b949e;
+  font-style: italic;
+}
+
+.markdown-body pre .hljs-keyword,
+.markdown-body pre .hljs-selector-tag,
+.markdown-body pre .hljs-literal,
+.markdown-body pre .hljs-section,
+.markdown-body pre .hljs-link,
+.markdown-body pre .hljs-type {
+  color: #ff7b72;
   font-weight: 700;
-  padding: 0.12rem 0.34rem;
+}
+
+.markdown-body pre .hljs-title,
+.markdown-body pre .hljs-title.class_,
+.markdown-body pre .hljs-title.function_ {
+  color: #d2a8ff;
+}
+
+.markdown-body pre .hljs-string,
+.markdown-body pre .hljs-regexp,
+.markdown-body pre .hljs-symbol,
+.markdown-body pre .hljs-bullet {
+  color: #a5d6ff;
+}
+
+.markdown-body pre .hljs-attr,
+.markdown-body pre .hljs-attribute,
+.markdown-body pre .hljs-name,
+.markdown-body pre .hljs-variable,
+.markdown-body pre .hljs-template-variable,
+.markdown-body pre .hljs-selector-class,
+.markdown-body pre .hljs-selector-id {
+  color: #7ee787;
+}
+
+.markdown-body pre .hljs-number,
+.markdown-body pre .hljs-meta,
+.markdown-body pre .hljs-built_in,
+.markdown-body pre .hljs-operator {
+  color: #ffa657;
+}
+
+.markdown-body pre .hljs-addition {
+  color: #aff5b4;
+  background: rgb(46 160 67 / 0.2);
+}
+
+.markdown-body pre .hljs-deletion {
+  color: #ffdcd7;
+  background: rgb(248 81 73 / 0.2);
+}
+
+/* Tables */
+.markdown-table-wrapper {
+  width: 100%;
+  max-width: 100%;
+  margin: 1.75rem 0;
+  overflow-x: auto;
+  border: 1px solid var(--markdown-line);
+  border-radius: 0.75rem;
+  background: var(--markdown-surface);
+  box-shadow: var(--future-inner, inset 0 1px 0 rgb(255 255 255 / 0.5));
+  scrollbar-color: color-mix(in srgb, var(--markdown-accent) 42%, transparent)
+    transparent;
+  scrollbar-width: thin;
+}
+
+.markdown-table-wrapper:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--markdown-accent) 62%, white);
+  outline-offset: 3px;
+}
+
+.markdown-body .markdown-table-wrapper table,
+.markdown-body > table {
+  display: table;
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: visible;
+  table-layout: auto;
+  text-align: left;
+  white-space: normal;
+}
+
+.markdown-body table thead {
+  background: color-mix(in srgb, var(--markdown-accent) 10%, transparent);
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  min-width: 8rem;
+  border: 0;
+  border-right: 1px solid var(--markdown-line);
+  border-bottom: 1px solid var(--markdown-line);
+  color: var(--markdown-muted);
+  padding: 0.75rem 0.9rem;
+  vertical-align: top;
+}
+
+.markdown-body table th:last-child,
+.markdown-body table td:last-child {
+  border-right: 0;
+}
+
+.markdown-body table tr:last-child td {
+  border-bottom: 0;
+}
+
+.markdown-body table th {
+  color: var(--markdown-ink);
+  font-weight: 700;
+}
+
+.markdown-body table tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--markdown-accent) 4%, transparent);
+}
+
+.markdown-body table tbody tr:hover {
+  background: color-mix(in srgb, var(--markdown-accent) 8%, transparent);
 }
 
 @media (max-width: 768px) {
@@ -602,24 +487,82 @@
   .future-site .markdown-body h3 {
     font-size: 1.45rem;
   }
+
+  .markdown-body pre {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    border-radius: 0.625rem;
+  }
+
+  .markdown-body pre > code,
+  .markdown-body pre > code.hljs {
+    font-size: 0.8rem;
+    line-height: 1.68;
+    padding: 0.9rem 1rem 1rem;
+  }
+
+  .markdown-table-wrapper {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    border-radius: 0.625rem;
+  }
 }
-/* 下面代码的灵感来自这个Issue: https://github.com/pd4d10/hashmd/issues/40 */
-/* ByteMD editor overrides	*/
+
+/* ByteMD editor overrides */
 .bytemd {
   @apply !rounded-xl !border-border !bg-background !text-foreground;
 }
+
 .bytemd-toolbar {
   @apply !rounded-none !border-border !bg-background;
 }
+
 .CodeMirror {
   @apply !bg-background !text-foreground;
 }
+
 .bytemd-split .bytemd-preview {
   @apply !border-l-border;
 }
+
 .bytemd-status {
   @apply !border-t-border;
 }
+
 .bytemd-toolbar-icon {
   @apply transition-all duration-100 hover:!bg-accent;
+}
+
+/* Editor syntax colors */
+.cm-header {
+  @apply !text-[#005cc5] dark:!text-[#79b8ff];
+}
+
+.cm-variable-2 {
+  @apply !text-[#24292e] dark:!text-[#e1e4e8];
+}
+
+.cm-comment {
+  @apply !text-[#032f62] dark:!text-[#9ecbff];
+}
+
+.cm-quote,
+.cm-link {
+  @apply !text-[#22863a] dark:!text-[#85e89d];
+}
+
+.cm-string {
+  @apply !break-all !text-[#24292e] dark:!text-[#e1e4e8];
+}
+
+.CodeMirror-cursor {
+  @apply !border-l-2 !border-l-[#204085] dark:!border-l-[#cee0fd];
+}
+
+.CodeMirror-linenumber {
+  @apply !text-foreground;
+}
+
+.CodeMirror-gutters {
+  @apply !border-r-muted !bg-background;
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,7 +1,7 @@
-@import "./bytemd.css";
-@import "./github.css";
 @import "bytemd/dist/index.css";
+@import "./github.css";
 @import "./github-dark.css";
+@import "./bytemd.css";
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Summary
- Server-render public blog Markdown with ByteMD `getProcessor()` and provide server-derived TOC data.
- Add lightweight client enhancement for copy-code and image zoom instead of hydrating the full Markdown body.
- Rework Markdown code block, inline code, table, heading, and dark-mode styles around shared tokens.
- Wrap Markdown tables in `.markdown-table-wrapper` while keeping native table layout to avoid page overflow/offset bugs.
- Remove `lowlight/all` and use common highlight aliases for blog languages.
- Harden `GsapReveal` so reveal items do not remain hidden and block Markdown interactions.

## Validation
- `pnpm exec eslint components/motion/gsap-reveal.tsx components/bytemd/markdown-enhancer.tsx components/bytemd/render-markdown.ts components/bytemd/config.ts components/bytemd/plugins/code-block.ts components/bytemd/plugins/hast.ts components/bytemd/plugins/inline-code.ts components/bytemd/plugins/pretty-link.ts components/bytemd/plugins/table.ts components/bytemd/plugins/index.ts components/markdown-toc/index.tsx 'app/(root)/blog/[slug]/page.tsx' features/blog/pages/blog-detail-page.tsx`
- `pnpm exec next build`

Notes: `pnpm exec next build` completes successfully; sandboxed build logs still show expected external DB/GitHub fetch failures during static generation. Full `pnpm lint` is still blocked by existing unrelated issues in `features/news/server/fetchers.ts`.